### PR TITLE
Example for configuring site-specific angular app dependencies 

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -12,7 +12,7 @@ angular.module('keypress', []).value('keypress', window.keypress);
 
 // ****** App Config ****** \\
 
-angular.module('bulbsCmsApp', [
+var appDependencies = [
   'ngCookies',
   'ngResource',
   'ngSanitize',
@@ -28,7 +28,13 @@ angular.module('bulbsCmsApp', [
   'moment',
   'PNotify',
   'keypress'
-])
+];
+// Potentially add app-specific dependencies
+if (window.additionalBulbsCMSDependencies) {
+  appDependencies = appDependencies.concat(window.additionalBulbsCMSDependencies);
+}
+
+angular.module('bulbsCmsApp', appDependencies)
 .config(function ($locationProvider, $routeProvider, $sceProvider, routes) {
   $locationProvider.html5Mode(true);
 


### PR DESCRIPTION
I was going to try using a treeview to (hopefully) improve the quiz cms stuff on clickhole but ran into the problem of not being able to add the treeview lib as a dependency to the angular app. Would something along these lines work, or is there a better way for me to do this? The idea is you configure some site-specific dependencies in that `additionalBulbsCMSDependencies` array before including the bulbs-cms angular code.

BTW, the vars name is little crazy and maybe we want to put it in a namespace or something?
