### PR TITLE
Fix tag endpoint

### DIFF
--- a/app/shared/api-services/tag/tag-factory.js
+++ b/app/shared/api-services/tag/tag-factory.js
@@ -4,7 +4,7 @@ angular.module('apiServices.tag.factory', [
   'apiServices'
 ])
   .factory('Tag', function (_, restmod) {
-    return restmod.model('tags').mix({
+    return restmod.model('tag').mix({
       $config: {
         name: 'Tag',
         plural: 'Tags',


### PR DESCRIPTION
@kand 

Correct endpoint is "/tag/"  https://github.com/theonion/django-bulbs/blob/master/bulbs/api/views.py#L513

Fixes Tag search in StarWipe CMS (currently 404-ing)