### PR TITLE
Re-enable Special Coverage campaign autocomplete via Tunic

### DIFF
--- a/app/components/special-coverage/special-coverage-edit/special-coverage-edit-directive.js
+++ b/app/components/special-coverage/special-coverage-edit/special-coverage-edit-directive.js
@@ -23,6 +23,8 @@ angular.module('specialCoverage.edit.directive', [
 
         $scope.needsSave = false;
 
+        $scope.tunicCampaignIdMapping = {};
+
         var modelId = $scope.getModelId();
         if (modelId === 'new') {
           // this is a new special coverage, build it
@@ -30,8 +32,13 @@ angular.module('specialCoverage.edit.directive', [
           $scope.isNew = true;
         } else {
           // this is an existing special coverage, find it
-          $scope.model = SpecialCoverage.$find($scope.getModelId());
+          $scope.model = SpecialCoverage.$find($scope.getModelId()).$then(function () {
+            $scope.model.$loadTunicCampaign().then(function (campaign) {
+              $scope.tunicCampaignIdMapping[campaign.id] = campaign;
+            });
+          });
         }
+
 
         window.onbeforeunload = function (e) {
           if (!_.isEmpty($scope.model.$dirty()) || $scope.isNew || $scope.needsSave) {
@@ -75,8 +82,21 @@ angular.module('specialCoverage.edit.directive', [
           });
         };
 
+        $scope.tunicCampaignFormatter = function (campaignId) {
+          if (campaignId in $scope.tunicCampaignIdMapping) {
+            var campaign = $scope.tunicCampaignIdMapping[campaignId];
+            return campaign.name + ' - ' + campaign.number;
+          }
+        };
+
         $scope.searchCampaigns = function (searchTerm) {
-          return Campaign.simpleSearch(searchTerm);
+          return $scope.model.$searchCampaigns({search: searchTerm}).then(function (campaigns) {
+            campaigns.forEach(function (campaign) {
+              $scope.tunicCampaignIdMapping[campaign.id] = campaign;
+            });
+            // Formatter expects list of IDs
+            return campaigns.map(function (campaign) { return campaign.id; });
+          });
         };
       },
       restrict: 'E',

--- a/app/components/special-coverage/special-coverage-edit/special-coverage-edit.html
+++ b/app/components/special-coverage/special-coverage-edit/special-coverage-edit.html
@@ -115,9 +115,8 @@
         <label for="specialCoverageCampaign">Sponsor Campaign</label>
         <autocomplete-basic
             class="form-control"
-            ng-if="!model.campaign || model.campaign.$resolved"
-            ng-model="model.campaign"
-            item-display-formatter="item.sponsorName + ' - ' + item.campaignLabel"
+            ng-model="model.tunicCampaignId"
+            item-display-formatter="tunicCampaignFormatter(item)"
             on-select="$parent.needsSave = true"
             input-id="specialCoverageCampaign"
             input-placeholder="e.g. 0-1337 Honda"

--- a/app/components/special-coverage/special-coverage-edit/special-coverage-edit.tests.js
+++ b/app/components/special-coverage/special-coverage-edit/special-coverage-edit.tests.js
@@ -1,0 +1,97 @@
+'use strict';
+
+describe('Directive: specialCoverageEdit', function () {
+
+  var
+    $q,
+    $directiveScope,
+    $rootScope;
+
+  beforeEach(function () {
+    module('bulbsCmsApp');
+    module('bulbsCmsApp.mockApi');
+    module('jsTemplates');
+
+    angular.module('specialCoverage.edit').constant('EXTERNAL_URL', 'onion.local');
+
+    inject(function ($, _$q_, $compile, _$rootScope_) {
+      $q = _$q_;
+      $rootScope = _$rootScope_;
+
+      var element = $compile('<special-coverage-edit model-id="1"></special-coverage-edit>')($rootScope.$new());
+      $rootScope.$digest();
+
+      $directiveScope = element.isolateScope();
+    });
+  });
+
+  describe('campaignId field', function () {
+
+    it('default campaign mapping is empty', function () {
+      expect($directiveScope.tunicCampaignIdMapping).toEqual({});
+    });
+
+    describe('tunicCampaignFormatter', function () {
+
+      it('should lookup campaign object by ID', function () {
+        $directiveScope.tunicCampaignIdMapping = {
+          123: {
+            name: 'Mike Burger',
+            number: 123
+          }
+        };
+        expect($directiveScope.tunicCampaignFormatter(123)).toEqual('Mike Burger - 123');
+      });
+
+      it('should return undefined if campaign not cached', function () {
+        expect($directiveScope.tunicCampaignFormatter()).toBeUndefined();
+        expect($directiveScope.tunicCampaignFormatter(123)).toBeUndefined();
+      });
+    });
+
+    describe('searchCampaigns', function () {
+
+      beforeEach(function() {
+
+        spyOn($directiveScope.model, '$searchCampaigns').andReturn($q.when([
+          {
+            name: 'one',
+            id: 1,
+            number: 1
+          },
+          {
+            name: 'two',
+            id: 2,
+            number: 2
+          }
+        ]));
+      });
+
+      it('should process search results', function () {
+
+        var searchResults;
+        $directiveScope.searchCampaigns('one').then(function (results) {
+          searchResults = results;
+        });
+
+        $rootScope.$apply();
+
+        expect($directiveScope.model.$searchCampaigns).toHaveBeenCalledWith({search: 'one'});
+        expect(searchResults).toEqual([1, 2]);
+        expect($directiveScope.tunicCampaignIdMapping).toEqual({
+          1: {
+            name: 'one',
+            id: 1,
+            number: 1,
+          },
+          2: {
+            name: 'two',
+            id: 2,
+            number: 2,
+          }
+        });
+      });
+    });
+  });
+
+});

--- a/app/shared/api-services/special-coverage/special-coverage-factory.js
+++ b/app/shared/api-services/special-coverage/special-coverage-factory.js
@@ -4,10 +4,11 @@ angular.module('apiServices.specialCoverage.factory', [
   'apiServices',
   'apiServices.campaign.factory',
   'apiServices.mixins.fieldDisplay',
+  'cms.tunic.config',
   'filters.moment',
   'VideohubClient.api'
 ])
-  .factory('SpecialCoverage', function (_, $parse, restmod, Video) {
+  .factory('SpecialCoverage', function (_, $http, $parse, $q, restmod, TunicConfig, Video) {
     var ACTIVE_STATES = {
       INACTIVE: 'Inactive',
       PROMOTED: 'Pin to HP'
@@ -98,6 +99,28 @@ angular.module('apiServices.specialCoverage.factory', [
           $loadVideosData: function () {
             _.each(this.videos, function (video) {
               video.$fetch();
+            });
+          },
+          /**
+           * Load campaign data from Tunic endpoint
+           */
+          $loadTunicCampaign: function () {
+            if (_.isNumber(this.tunicCampaignId)) {
+              return $http.get(TunicConfig.buildBackendApiUrl('campaign/' + this.tunicCampaignId + '/')).then(function (result) {
+                return result.data;
+              });
+            }
+            return $q.reject();
+          },
+          /**
+           * Load campaign search results from Tunic endpoint
+           */
+          $searchCampaigns: function (params) {
+
+            return $http.get(TunicConfig.buildBackendApiUrl('campaign/'), {
+              params: params,
+            }).then(function (response) {
+              return response.data.results;
             });
           },
           /**


### PR DESCRIPTION
Parking this here until ready to flip CMS FE to Tunic-backed campaigns.

(This was originally deployed to Onion CMS, then reverted until rest of infrastructure is built out.)