### PR TITLE
Speed up $digest for large articles

### DIFF
--- a/app/scripts/controllers/contentedit.js
+++ b/app/scripts/controllers/contentedit.js
@@ -255,9 +255,11 @@ angular.module('bulbsCmsApp')
 
     // keep track of if article is dirty or not
     $scope.articleIsDirty = false;
-    $scope.$watch('article', function () {
-      $scope.articleIsDirty = !angular.equals($scope.article, $scope.last_saved_article);
-    }, true);
+    $scope.$watch(function () {
+      return !angular.equals($scope.article, $scope.last_saved_article);
+    }, function (isDirty) {
+      $scope.articleIsDirty = isDirty;
+    });
 
     $scope.$watch('articleIsDirty', function () {
       if ($scope.articleIsDirty) {


### PR DESCRIPTION
Clickventure edit pages have a significant slowdown when the Clickventure gets very large.

For `$watch` statements with the 3rd argument set to `true`, a `angular.copy` is run every digest cycle on the watched statement to prepare for future equality checks, this is the recommended technique for watching changes on entire objects. However, in our case, `article` can become a very large object in cases such as Clickventure.

This PR changes that `$watch` to instead only check equality between the current `article` and `last_saved_article` on scope without causing `angular.copy` to fire, which is significantly faster.