### PR TITLE
Fix TunicConfig so all requests are not intercepted by default

### DIFF
--- a/app/shared/tunic/tunic-config.js
+++ b/app/shared/tunic/tunic-config.js
@@ -64,7 +64,8 @@ angular.module('cms.tunic.config', [
            * @returns {boolean} true if url should be intercepted, false otherwise.
            */
           shouldBeIntercepted: function (url) {
-            return url.startsWith(backendRoot + apiPath);
+            var urlTest = backendRoot + apiPath;
+            return urlTest !== '' && url.startsWith(urlTest);
           }
         };
       };


### PR DESCRIPTION
`TunicConfig.shouldBeIntercepted` will no longer return `true` if `TunicConfig` has not been setup.