### PR TITLE
Bug fixes for polls cms

### DIFF
--- a/app/components/polls/polls-edit/polls-edit-directive.js
+++ b/app/components/polls/polls-edit/polls-edit-directive.js
@@ -54,18 +54,26 @@ angular.module('polls.edit.directive', [
         // in such a way that modal-on-close="validatePublication()"
         // fires before the scope model data has changed.
         $timeout(function () {
+          var pollForm = $scope.pollForm;
           var published = $scope.model.published;
           var endDate = $scope.model.end_date;
-          var publishedField = $scope.pollForm.published;
-          var endDateField = $scope.pollForm.endDate;
+          var publishedField = pollForm.published;
+          var endDateField = pollForm.endDate;
 
-          publishedField.$setValidity(
+          pollForm.$setValidity(
             'requiredWithEndDate',
-            !(endDate && !published)
+            !(endDate && !published),
+            publishedField
           );
-          endDateField.$setValidity(
+
+          var comesAfterPublishedValid = true;
+          if (endDate && published) {
+            comesAfterPublishedValid = published.isBefore(endDate);
+          }
+          pollForm.$setValidity(
             'comesAfterPublished',
-            endDate && published && published.isBefore(endDate)
+            comesAfterPublishedValid,
+            endDateField
           );
         });
       };

--- a/app/components/polls/polls-edit/polls-edit-directive.js
+++ b/app/components/polls/polls-edit/polls-edit-directive.js
@@ -54,11 +54,10 @@ angular.module('polls.edit.directive', [
         // in such a way that modal-on-close="validatePublication()"
         // fires before the scope model data has changed.
         $timeout(function () {
-          var pollForm = $scope.pollForm;
           var published = $scope.model.published;
           var endDate = $scope.model.end_date;
-          var publishedField = pollForm.published;
-          var endDateField = pollForm.endDate;
+          var publishedField = $scope.pollForm.published;
+          var endDateField = $scope.pollForm.endDate;
 
           publishedField.$setValidity(
             'requiredWithEndDate',

--- a/app/components/polls/polls-edit/polls-edit-directive.js
+++ b/app/components/polls/polls-edit/polls-edit-directive.js
@@ -60,20 +60,18 @@ angular.module('polls.edit.directive', [
           var publishedField = pollForm.published;
           var endDateField = pollForm.endDate;
 
-          pollForm.$setValidity(
+          publishedField.$setValidity(
             'requiredWithEndDate',
-            !(endDate && !published),
-            publishedField
+            !(endDate && !published)
           );
 
           var comesAfterPublishedValid = true;
           if (endDate && published) {
             comesAfterPublishedValid = published.isBefore(endDate);
           }
-          pollForm.$setValidity(
+          endDateField.$setValidity(
             'comesAfterPublished',
-            comesAfterPublishedValid,
-            endDateField
+            comesAfterPublishedValid
           );
         });
       };

--- a/app/components/polls/polls-edit/polls-edit-directive.tests.js
+++ b/app/components/polls/polls-edit/polls-edit-directive.tests.js
@@ -37,11 +37,17 @@ describe('Directive: pollsEdit', function () {
     expect(scope.isNew).toBe(true);
   });
 
-  it('has appropriate poll fields', function () {
-    expect(element.html()).toContain('Poll Name');
-    expect(element.html()).toContain('Poll End Date');
+  it('has appropriate new poll fields', function () {
     expect(element.html()).toContain('Question');
     expect(element.html()).toContain('Responses');
+  });
+
+  it('has appropriate edit poll fields', function () {
+    scope.$apply(function () {
+      scope.model.id = '1';
+    });
+    expect(element.html()).toContain('Poll Name');
+    expect(element.html()).toContain('Poll End Date');
   });
 
   it('scope initializes with 3 empty answer objects', function () {
@@ -103,6 +109,14 @@ describe('Directive: pollsEdit', function () {
   });
 
   describe('validation messages', function () {
+    beforeEach(function () {
+      // forces directive into 'edit' mode
+      // helps us test ALL validations
+      scope.$apply(function () {
+        scope.model.id = 1;
+      });
+    });
+
     it('shows validation message when title is valid', function () {
       var input = element.find('input[name=title]');
       input.val('').trigger('input');

--- a/app/components/polls/polls-edit/polls-edit-directive.tests.js
+++ b/app/components/polls/polls-edit/polls-edit-directive.tests.js
@@ -102,9 +102,7 @@ describe('Directive: pollsEdit', function () {
     });
   });
 
-  describe('validations', function () {
-    // These validation tests follow this format:
-
+  describe('validation messages', function () {
     it('shows validation message when title is valid', function () {
       var input = element.find('input[name=title]');
       input.val('').trigger('input');

--- a/app/components/polls/polls-edit/polls-edit.html
+++ b/app/components/polls/polls-edit/polls-edit.html
@@ -48,7 +48,9 @@
       </div>
     </div>
 
-    <div class="row poll-startdate">
+    <div
+        ng-if="model.id"
+        class="row poll-startdate">
       <div class="form-group col-lg-push-3 col-lg-6">
         <label for="pollStartDate">
           Poll Start Date
@@ -86,7 +88,9 @@
       </div>
     </div>
 
-    <div class="row poll-end-date">
+    <div
+        ng-if="model.id"
+        class="row poll-end-date">
       <div class="form-group col-lg-push-3 col-lg-6">
         <label for="pollEndDate">
           Poll End Date


### PR DESCRIPTION
- Don't allow setting published/end dates on new polls.
  This allows for a bizarre edge case where you might `POST { activationDate: null, ... }`
  to sodahead. They do not like this for new polls. Hiding the date fields until the poll
  exsists mitigates the issue.

- Fix the form validation, there was a flaw in the date validation logic that left
  `pollForm.$valid` as `undefined`, no bueno.

@MelizzaP @kand @spra85