### PR TITLE
Add "core_section" filtering to ensure required tag is within first page of tag search results

### DIFF
--- a/app/scripts/directives/create-content.js
+++ b/app/scripts/directives/create-content.js
@@ -25,7 +25,8 @@ angular.module('bulbsCmsApp')
             IfExistsElse.ifExistsElse(
               ContentFactory.all('tag').getList({
                 ordering: 'name',
-                search: $scope.tag
+                search: $scope.tag,
+                types: 'core_section'
               }),
               {slug: $scope.tag},
               function (tag) { $scope.init.tags = [tag]; $scope.gotTags = true; },

--- a/app/scripts/directives/sectionsfield.js
+++ b/app/scripts/directives/sectionsfield.js
@@ -24,7 +24,8 @@ angular.module('bulbsCmsApp')
           IfExistsElse.ifExistsElse(
             ContentFactory.all('tag').getList({
               ordering: 'name',
-              search: tagVal
+              search: tagVal,
+              types: 'core_section'
             }),
             {name: tagVal},
             function (tag) { scope.article.tags.push(tag); },


### PR DESCRIPTION
This fixes AVC "Film Review" content creation issues.

Guess: ES search results just started returning "Film" on page 2 in production today after massive ES re-indexing for unrelated Instant Articles rollout. 

This code should be re-written to not do a generic tag search to check for a single tag's existence.

For create-content, I verified that all tag types will match with this new "core_section" type filter. 
@kand 