### PR TITLE
no error on non-string types in builders

### DIFF
--- a/app/components/static-image/static-image.js
+++ b/app/components/static-image/static-image.js
@@ -20,7 +20,7 @@ angular.module('bulbs.cms.staticImage', [
 
           scope.$watch('image', function () {
             if (scope.image && scope.image.id) {
-              scope.imageUrl = CmsConfig.buildImageApiUrl(ratio, '' + scope.image.id, '1200.jpg');
+              scope.imageUrl = CmsConfig.buildImageApiUrl(ratio, scope.image.id, '1200.jpg');
             } else {
               scope.imageUrl = false;
             }

--- a/app/scripts/controllers/videothumbnailmodal.js
+++ b/app/scripts/controllers/videothumbnailmodal.js
@@ -22,7 +22,7 @@ angular.module('bulbsCmsApp')
 
     $scope.$watch('video.poster', function () {
       if (!$scope.video || !$scope.video.poster) { return; }
-      var defaultUrl = CmsConfig.buildVideoThumbnailUrl('' + videoId, 'thumbnail_{{thumbnail}}.png');
+      var defaultUrl = CmsConfig.buildVideoThumbnailUrl(videoId, 'thumbnail_{{thumbnail}}.png');
       var thumbnailIndex = defaultUrl.indexOf('{{thumbnail}}');
       if ($scope.video.poster.indexOf(defaultUrl.substr(0, thumbnailIndex)) === 0) {
         $scope.currentThumbnail = Number($scope.video.poster.substr(thumbnailIndex, 4));
@@ -35,7 +35,7 @@ angular.module('bulbsCmsApp')
     $scope.$watch('uploadedImage.id', function () {
       if ($scope.uploadedImage.id) {
         $scope.video.poster =
-          CmsConfig.buildImageApiUrl('16x9', '' + $scope.uploadedImage.id, '1200.jpg');
+          CmsConfig.buildImageApiUrl('16x9', $scope.uploadedImage.id, '1200.jpg');
       }
     });
 
@@ -61,7 +61,7 @@ angular.module('bulbsCmsApp')
     };
 
     function compilePosterUrl(thumbnail) {
-      return CmsConfig.buildVideoThumbnailUrl('' + videoId, 'thumbnail_' + pad4(thumbnail) + '.png');
+      return CmsConfig.buildVideoThumbnailUrl(videoId, 'thumbnail_' + pad4(thumbnail) + '.png');
     }
 
     function pad4(num) {

--- a/app/shared/cms-config/cms-config.js
+++ b/app/shared/cms-config/cms-config.js
@@ -15,15 +15,9 @@ angular.module('bulbs.cms.config', [
         }
         throw new CmsConfigError(errorMsg);
       };
-      var pathBuilder = function (start, errorMsg) {
+      var pathBuilder = function (start) {
         return function () {
-          return Utils.path.join(checkOrError(
-            arguments,
-            function (args) {
-              return _.every(args, _.isString);
-            },
-            errorMsg
-          ));
+          return Utils.path.join(arguments);
         }.bind(null, start);
       };
 
@@ -240,54 +234,18 @@ angular.module('bulbs.cms.config', [
       this.$get = [
         function () {
           return {
-            buildComponentPath: pathBuilder(
-              componentPath,
-              'value given to component path build must be a string!'
-            ),
-            buildContentPartialsPath: pathBuilder(
-              contentPartialsPath,
-              'value given to content partials path build must be a string!'
-            ),
-            buildDirectivePartialsPath: pathBuilder(
-              directivePartialsPath,
-              'value given to directive partials path build must be a string!'
-            ),
-            buildExternalUrl: pathBuilder(
-              externalUrl,
-              'value given to external url build must be a string!'
-            ),
-            buildFirebaseUrl: pathBuilder(
-              firebaseUrl,
-              'value given to firebase url build must be a string!'
-            ),
-            buildFirebaseSiteUrl: pathBuilder(
-              Utils.path.join(firebaseUrl, firebaseSiteRoot),
-              'value given to firebase site url build must be a string!'
-            ),
-            buildImageApiUrl: pathBuilder(
-              imageApiUrl,
-              'value given to image api url build must be a string!'
-            ),
-            buildInternalUrl: pathBuilder(
-              internalUrl,
-              'value given to internal url build must be a string!'
-            ),
-            buildSharedPath: pathBuilder(
-              sharedPath,
-              'value given to shared path build must be a string!'
-            ),
-            buildUnpublishedUrl: pathBuilder(
-              Utils.path.join(internalUrl, unpublishedPath),
-              'value given to unpublished url build must be a string!'
-            ),
-            buildVideoUrl: pathBuilder(
-              Utils.path.join(externalUrl, videoPath),
-              'value given to video url build must be a string!'
-            ),
-            buildVideoThumbnailUrl: pathBuilder(
-              videoThumbnailUrl,
-              'value given to video thumbnail url build must be a string!'
-            ),
+            buildComponentPath: pathBuilder(componentPath),
+            buildContentPartialsPath: pathBuilder(contentPartialsPath),
+            buildDirectivePartialsPath: pathBuilder(directivePartialsPath),
+            buildExternalUrl: pathBuilder(externalUrl),
+            buildFirebaseUrl: pathBuilder(firebaseUrl),
+            buildFirebaseSiteUrl: pathBuilder(Utils.path.join(firebaseUrl, firebaseSiteRoot)),
+            buildImageApiUrl: pathBuilder(imageApiUrl),
+            buildInternalUrl: pathBuilder(internalUrl),
+            buildSharedPath: pathBuilder(sharedPath),
+            buildUnpublishedUrl: pathBuilder(Utils.path.join(internalUrl, unpublishedPath)),
+            buildVideoUrl: pathBuilder(Utils.path.join(externalUrl, videoPath)),
+            buildVideoThumbnailUrl: pathBuilder(videoThumbnailUrl),
             getAutoAddAuthor: _.constant(autoAddAuthor),
             getCmsName: _.constant(cmsName),
             getDateTimeFormatHumanReadable: _.constant(dateTimeFormatHumanReadable),

--- a/app/shared/cms-config/cms-config.tests.js
+++ b/app/shared/cms-config/cms-config.tests.js
@@ -85,16 +85,6 @@ describe('CmsConfig', function () {
             .to.equal(path + templatePath);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildComponentPath(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to component path build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -129,16 +119,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildContentPartialsPath(templatePath))
             .to.equal(path + templatePath);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildContentPartialsPath(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to content partials path build must be a string!'
-          );
         });
 
         it('should throw an error if the given value is not a string', function () {
@@ -229,16 +209,6 @@ describe('CmsConfig', function () {
             .to.equal(path + templatePath);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildDirectivePartialsPath(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to directive partials path build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -275,16 +245,6 @@ describe('CmsConfig', function () {
             .to.equal(url + path);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildExternalUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to external url build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -319,16 +279,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildInternalUrl(path))
             .to.equal(url + path);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildInternalUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to internal url build must be a string!'
-          );
         });
 
         it('should throw an error if the given value is not a string', function () {
@@ -447,16 +397,6 @@ describe('CmsConfig', function () {
             .to.equal(path + templatePath);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildSharedPath(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to shared path build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -497,16 +437,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildUnpublishedUrl(someId))
             .to.equal(internalUrl + path + someId);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildUnpublishedUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to unpublished url build must be a string!'
-          );
         });
 
         it('should throw an error if the given value is not a string', function () {
@@ -551,16 +481,6 @@ describe('CmsConfig', function () {
             .to.equal(externalUrl + path + someId);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildVideoUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to video url build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -596,16 +516,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildVideoThumbnailUrl(someVideo, someImage))
             .to.equal(url + someVideo + someImage);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildVideoThumbnailUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to video thumbnail url build must be a string!'
-          );
         });
 
         it('should throw an error if the given value is not a string', function () {
@@ -646,16 +556,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildFirebaseUrl(path))
             .to.equal(url + path);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildFirebaseUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to firebase url build must be a string!'
-          );
         });
 
         it('should throw an error if the given value is not a string', function () {
@@ -732,16 +632,6 @@ describe('CmsConfig', function () {
             .to.equal(firebaseUrl + path + someNode);
         });
 
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildFirebaseSiteUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to firebase site url build must be a string!'
-          );
-        });
-
         it('should throw an error if the given value is not a string', function () {
 
           expect(function () {
@@ -808,16 +698,6 @@ describe('CmsConfig', function () {
 
           expect(sealedConfigs().buildImageApiUrl(somePath))
             .to.equal(imageUrl + somePath);
-        });
-
-        it('should throw an error if value given to getter is not a string', function () {
-
-          expect(function () {
-            sealedConfigs().buildImageApiUrl(123);
-          }).to.throw(
-            BulbsCmsConfigError,
-            'Configuration Error (CmsConfig): value given to image api url build must be a string!'
-          );
         });
 
         it('should throw an error if given value is not a string', function () {


### PR DESCRIPTION
Path builders should be allowed to take non-string arguments. A common use case is passing numbers for ids in urls.