### PR TITLE
CMS Notification cleanup

### DIFF
--- a/app/mocks/api.js
+++ b/app/mocks/api.js
@@ -207,8 +207,8 @@ angular.module('bulbsCmsApp.mockApi', [
     }];
     $httpBackend.whenGET(/\/cms\/api\/v1\/content-type\/(\?search=.*)?/).respond(mockApiData.content_types);
 
-    // notifications
-    mockApiData.notifications = [{
+    // CMS notifications
+    mockApiData.cmsNotifications = [{
         id: 0,
         title: 'We\'ve Made An Update!',
         body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin quis aliquet risus, eget vulputate nibh. Fusce egestas porttitor libero in faucibus. Aliquam at orci eget massa tristique condimentum vel sit amet ipsum. Nulla tincidunt arcu tortor, a pulvinar mauris convallis id. Quisque imperdiet id ex ac fringilla. Aliquam fringilla dolor nec enim iaculis iaculis sed ac lacus. Nulla id condimentum magna. Aliquam dictum justo tortor, vitae blandit odio aliquet sagittis.',
@@ -238,22 +238,22 @@ angular.module('bulbsCmsApp.mockApi', [
         post_date: today.format(),
         notify_end_date: today.clone().add({days: 3}).format()
     }];
-    $httpBackend.whenGET('/cms/api/v1/notifications/').respond(mockApiData.notifications);
-    $httpBackend.whenPOST('/cms/api/v1/notifications/').respond(200, {
+    $httpBackend.whenGET('/cms/api/v1/cms_notifications/').respond(mockApiData.cmsNotifications);
+    $httpBackend.whenPOST('/cms/api/v1/cms_notifications/').respond(200, {
       id: 5,
       title: 'New Notification',
       body: 'Ipsum ipsum ipsum. This was POSTed here.',
       post_date: today.clone().add({days: 1}).format(),
       notify_end_date: today.clone().add({days: 4}).format()
     });
-    $httpBackend.whenPUT(/\/cms\/api\/v1\/notifications\/(\d+)\//).respond(200, {
+    $httpBackend.whenPUT(/\/cms\/api\/v1\/cms_notifications\/(\d+)\//).respond(200, {
       id: 5,
       title: 'Updated Notification',
       body: 'This was PUT here.',
       post_date: today.clone().add({days: 1}).format(),
       notify_end_date: today.clone().add({days: 4}).format()
     });
-    $httpBackend.whenDELETE(/\/cms\/api\/v1\/notifications\/(\d+)\//).respond(200);
+    $httpBackend.whenDELETE(/\/cms\/api\/v1\/cms_notifications\/(\d+)\//).respond(200);
 
     //current user
     $httpBackend.whenGET(/\/users\/me\/?/).respond({

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -82,7 +82,7 @@ angular.module('bulbsCmsApp', [
       templateUrl: '/views/targeting-editor.html',
       controller: 'TargetingCtrl'
     })
-    .when('/cms/app/notifications/', {
+    .when('/cms/app/cms-notifications/', {
       templateUrl: '/views/cms-notifications.html',
       controller: 'CmsNotificationsCtrl'
     })

--- a/app/scripts/controllers/cms-notification.js
+++ b/app/scripts/controllers/cms-notification.js
@@ -65,7 +65,7 @@ angular.module('bulbsCmsApp')
             $scope.cmsNotificationDirty = false;
           })
           .catch(function (error) {
-            console.log('CMS Notification save failed', error);
+            console.log('CMS Alert save failed', error);
           });
 
       }
@@ -81,7 +81,7 @@ angular.module('bulbsCmsApp')
 
         $scope.$parent.$deleteCmsNotification($scope.cmsNotification)
           .catch(function (error) {
-            console.log('CMS Notification delete failed', error);
+            console.log('CMS Alert delete failed', error);
           });
 
       }

--- a/app/scripts/controllers/cms-notification.js
+++ b/app/scripts/controllers/cms-notification.js
@@ -6,42 +6,42 @@ angular.module('bulbsCmsApp')
     var valid = function () {
       $scope.postDateValid = $scope.postDate && (!$scope.notifyEndDate || $scope.postDate < $scope.notifyEndDate);
       $scope.notifyEndDateValid = $scope.notifyEndDate && $scope.postDate && $scope.notifyEndDate > $scope.postDate;
-      $scope.titleValid = $scope.notification.title && $scope.notification.title.length > 0 && $scope.notification.title.length <= 110;
+      $scope.titleValid = $scope.cmsNotification.title && $scope.cmsNotification.title.length > 0 && $scope.cmsNotification.title.length <= 110;
 
-      $scope.notificationValid = $scope.postDateValid && $scope.notifyEndDateValid && $scope.titleValid;
+      $scope.cmsNotificationValid = $scope.postDateValid && $scope.notifyEndDateValid && $scope.titleValid;
     };
 
     // Note: use middle man for handling dates since a bug in angular.js version causes moment to not work with
     //  angular.copy. So instead of keeping notification dates as moments, keep them as strings and use moment objects
     //  for interactions.
 
-    $scope.postDate = $scope.notification.post_date ? moment($scope.notification.post_date) : null;
+    $scope.postDate = $scope.cmsNotification.post_date ? moment($scope.cmsNotification.post_date) : null;
     $scope.$watch('postDate', function () {
       if ($scope.postDate) {
         // set notification's post date as the string version of the moment object
-        $scope.notification.post_date = $scope.postDate.format();
+        $scope.cmsNotification.post_date = $scope.postDate.format();
         // automatically set the notify end date as 3 days after post date
         $scope.notifyEndDate = $scope.postDate.clone().add({days: 3});
       } else {
-        $scope.notification.post_date = null;
+        $scope.cmsNotification.post_date = null;
       }
     });
 
-    $scope.notifyEndDate = $scope.notification.notify_end_date ? moment($scope.notification.notify_end_date) : null;
+    $scope.notifyEndDate = $scope.cmsNotification.notify_end_date ? moment($scope.cmsNotification.notify_end_date) : null;
     $scope.$watch('notifyEndDate', function () {
       if ($scope.notifyEndDate) {
         // set notification's post date as the string version of the moment object
-        $scope.notification.notify_end_date = $scope.notifyEndDate.format();
+        $scope.cmsNotification.notify_end_date = $scope.notifyEndDate.format();
       } else {
-        $scope.notification.notify_end_date = null;
+        $scope.cmsNotification.notify_end_date = null;
       }
     });
 
     // keep track of changes to this notification
-    $scope.notificationDirty = false;
-    $scope.$watch('notification', function (newValue, oldValue) {
+    $scope.cmsNotificationDirty = false;
+    $scope.$watch('cmsNotification', function (newValue, oldValue) {
       if (!angular.equals(newValue, oldValue)) {
-        $scope.notificationDirty = true;
+        $scope.cmsNotificationDirty = true;
 
         // do some validation here
         valid();
@@ -55,17 +55,17 @@ angular.module('bulbsCmsApp')
     /**
      * Save this notification using the parent scope.
      */
-    $scope.saveNotification = function () {
+    $scope.saveCmsNotification = function () {
 
-      if ($scope.$parent.userIsSuperuser && $scope.notificationDirty && $scope.notificationValid) {
+      if ($scope.$parent.userIsSuperuser && $scope.cmsNotificationDirty && $scope.cmsNotificationValid) {
 
-        $scope.$parent.$saveNotification($scope.notification)
-          .then(function (newNotification) {
-            $scope.notification = newNotification;
-            $scope.notificationDirty = false;
+        $scope.$parent.$saveCmsNotification($scope.cmsNotification)
+          .then(function (newCmsNotification) {
+            $scope.cmsNotification = newCmsNotification;
+            $scope.cmsNotificationDirty = false;
           })
           .catch(function (error) {
-            console.log('Notification save failed', error);
+            console.log('CMS Notification save failed', error);
           });
 
       }
@@ -75,13 +75,13 @@ angular.module('bulbsCmsApp')
     /**
      * Delete this notification using the parent scope.
      */
-    $scope.deleteNotification = function () {
+    $scope.deleteCmsNotification = function () {
 
       if ($scope.$parent.userIsSuperuser) {
 
-        $scope.$parent.$deleteNotification($scope.notification)
+        $scope.$parent.$deleteCmsNotification($scope.cmsNotification)
           .catch(function (error) {
-            console.log('Notification delete failed', error);
+            console.log('CMS Notification delete failed', error);
           });
 
       }

--- a/app/scripts/controllers/cms-notifications.js
+++ b/app/scripts/controllers/cms-notifications.js
@@ -4,7 +4,7 @@ angular.module('bulbsCmsApp')
   .controller('CmsNotificationsCtrl', function ($q, $window, $scope, CmsConfig,
       CmsNotificationsApi, CurrentUser, _, moment) {
 
-    $window.document.title = CmsConfig.getCmsName() + ' | Notifications';
+    $window.document.title = CmsConfig.getCmsName() + ' | CMS Notifications';
 
     // get user info
     CurrentUser.$retrieveData().then(function (user) {
@@ -12,20 +12,20 @@ angular.module('bulbsCmsApp')
         $scope.userIsSuperuser = true;
       }
 
-      // get list of notifications
-      CmsNotificationsApi.getList().then(function (notifications) {
-        // filter out notifications for regular users that have a post date in the future
+      // get list of CMS notifications
+      CmsNotificationsApi.getList().then(function (cmsNotifications) {
+        // filter out CMS notifications for regular users that have a post date in the future
         var removeIndicies = [];
-        _.each(notifications, function (notification, i) {
-          if (!user.is_superuser && moment(notification.post_date).isAfter(moment())) {
+        _.each(cmsNotifications, function (cmsNotification, i) {
+          if (!user.is_superuser && moment(cmsNotification.post_date).isAfter(moment())) {
             removeIndicies.push(i);
           }
         });
         _.each(removeIndicies, function (i) {
-          notifications.splice(i, 1);
+          cmsNotifications.splice(i, 1);
         });
 
-        $scope.notifications = notifications;
+        $scope.cmsNotifications = cmsNotifications;
       });
     });
 
@@ -34,16 +34,16 @@ angular.module('bulbsCmsApp')
      *
      * @return  new notification with only nulled date properties.
      */
-    $scope.newNotification = function () {
+    $scope.newCmsNotification = function () {
 
-      var notification = {
+      var cmsNotification = {
         post_date: null,
         notify_end_date: null
       };
 
-      $scope.notifications.unshift(notification);
+      $scope.cmsNotifications.unshift(cmsNotification);
 
-      return notification;
+      return cmsNotification;
 
     };
 
@@ -53,25 +53,25 @@ angular.module('bulbsCmsApp')
      * @param notification  Notification to save.
      * @return  promise that resolves when notification is saved.
      */
-    $scope.$saveNotification = function (notification) {
+    $scope.$saveCmsNotification = function (cmsNotification) {
 
       var saveDefer = $q.defer(),
           savePromise = saveDefer.promise;
 
       if ($scope.userIsSuperuser) {
-        if ('id' in notification) {
+        if ('id' in cmsNotification) {
           // this thing already exists, update it
-          notification.put().then(function (updatedNotification) {
-            saveDefer.resolve(updatedNotification);
+          cmsNotification.put().then(function (updatedCmsNotification) {
+            saveDefer.resolve(updatedCmsNotification);
           });
         } else {
           // a new notification, post it to the list
-          $scope.notifications.post(notification)
-            .then(function (newNotification) {
+          $scope.cmsNotifications.post(cmsNotification)
+            .then(function (newCmsNotification) {
               // save succeeded, replace notification with restangularized notification
-              var i = $scope.notifications.indexOf(notification);
-              $scope.notifications[i] = newNotification;
-              saveDefer.resolve(newNotification);
+              var i = $scope.cmsNotifications.indexOf(cmsNotification);
+              $scope.cmsNotifications[i] = newCmsNotification;
+              saveDefer.resolve(newCmsNotification);
             })
             .catch(function (error) {
               saveDefer.reject(error);
@@ -91,23 +91,23 @@ angular.module('bulbsCmsApp')
      * @param notification  Notification to delete.
      * @return  promise that resolves when notification is deleted.
      */
-    $scope.$deleteNotification = function (notification) {
+    $scope.$deleteCmsNotification = function (cmsNotification) {
 
       var deleteDefer = $q.defer(),
           deletePromise = deleteDefer.promise,
           removeFromList = function (index) {
-            $scope.notifications.splice(index, 1);
+            $scope.cmsNotifications.splice(index, 1);
             deleteDefer.resolve();
           };
 
       if ($scope.userIsSuperuser) {
         // find notification in list
-        var i = $scope.notifications.indexOf(notification);
+        var i = $scope.cmsNotifications.indexOf(cmsNotification);
         if (i > -1) {
           // notification in list, check if it is a restangular object and has a remove function
-          if (_.isFunction(notification.remove)) {
+          if (_.isFunction(cmsNotification.remove)) {
             // has remove, call it and resolve promise
-            notification.remove()
+            cmsNotification.remove()
               .then(function () {
                 removeFromList(i);
               })

--- a/app/scripts/controllers/cms-notifications.js
+++ b/app/scripts/controllers/cms-notifications.js
@@ -88,7 +88,7 @@ angular.module('bulbsCmsApp')
     /**
      * Delete given notification from the database.
      *
-     * @param notification  Notification to delete.
+     * @param cmsNotification  Notification to delete.
      * @return  promise that resolves when notification is deleted.
      */
     $scope.$deleteCmsNotification = function (cmsNotification) {

--- a/app/scripts/controllers/cms-notifications.js
+++ b/app/scripts/controllers/cms-notifications.js
@@ -4,7 +4,7 @@ angular.module('bulbsCmsApp')
   .controller('CmsNotificationsCtrl', function ($q, $window, $scope, CmsConfig,
       CmsNotificationsApi, CurrentUser, _, moment) {
 
-    $window.document.title = CmsConfig.getCmsName() + ' | CMS Notifications';
+    $window.document.title = CmsConfig.getCmsName() + ' | CMS Alerts';
 
     // get user info
     CurrentUser.$retrieveData().then(function (user) {

--- a/app/scripts/controllers/cms-notify-container.js
+++ b/app/scripts/controllers/cms-notify-container.js
@@ -4,7 +4,7 @@
 /* jshint newcap: false */
 
 /**
- * Controller for notifications bar that is displayed to users.
+ * Controller for CMS notifications bar that is displayed to users.
  */
 angular.module('bulbsCmsApp')
   .controller('CmsNotifyContainerCtrl', function ($scope, ipCookie, moment, CmsNotificationsApi, URLify, _) {
@@ -12,33 +12,33 @@ angular.module('bulbsCmsApp')
     var genCookieKey = function (id) {
       return 'dismissed-cms-notification-' + id;
     };
-    var updateNotificationsDisplay = function (notifications) {
+    var updateCmsNotificationsDisplay = function (cmsNotifications) {
       var now = moment();
-      $scope.notifications = _.filter(notifications, function (notification) {
-        // show notifications where there is no dismiss cookie and post_date < now < notify_end_date
-        if (!ipCookie(genCookieKey(notification.id)) &&
-              moment(notification.post_date).isBefore(now) &&
-              moment(notification.notify_end_date).isAfter(now)) {
+      $scope.cmsNotifications = _.filter(cmsNotifications, function (cmsNotification) {
+        // show CMS notifications where there is no dismiss cookie and post_date < now < notify_end_date
+        if (!ipCookie(genCookieKey(cmsNotification.id)) &&
+              moment(cmsNotification.post_date).isBefore(now) &&
+              moment(cmsNotification.notify_end_date).isAfter(now)) {
           return true;
         }
       });
     };
 
-    // show notifications
-    CmsNotificationsApi.getList().then(function (notifications) {
-      updateNotificationsDisplay(notifications);
+    // show CMS notifications
+    CmsNotificationsApi.getList().then(function (cmsNotifications) {
+      updateCmsNotificationsDisplay(cmsNotifications);
     });
 
-    $scope.dismissNotification = function (notification) {
+    $scope.dismissCmsNotification = function (cmsNotification) {
       // add dismiss cookie
-      var cookieKey = URLify(genCookieKey(notification.id));
+      var cookieKey = URLify(genCookieKey(cmsNotification.id));
       ipCookie(cookieKey, true, {
-        expires: moment(notification.notify_end_date).add({days: 1}).diff(moment(), 'days'),
+        expires: moment(cmsNotification.notify_end_date).add({days: 1}).diff(moment(), 'days'),
         path: '/cms/app'
       });
 
       // hide notification
-      updateNotificationsDisplay($scope.notifications);
+      updateCmsNotificationsDisplay($scope.cmsNotifications);
     };
 
   });

--- a/app/scripts/directives/cms-notification.js
+++ b/app/scripts/directives/cms-notification.js
@@ -6,7 +6,7 @@ angular.module('bulbsCmsApp')
       restrict: 'E',
       templateUrl: '/views/cms-notification.html',
       scope: {
-        notification: '='
+        cmsNotification: '='
       },
       controller: 'CmsNotificationCtrl'
     };

--- a/app/scripts/services/cmsnotificationsapi.js
+++ b/app/scripts/services/cmsnotificationsapi.js
@@ -2,5 +2,5 @@
 
 angular.module('bulbsCmsApp')
   .factory('CmsNotificationsApi', function ($q, ContentFactory) {
-    return ContentFactory.service('notifications');
+    return ContentFactory.service('cms_notifications');
   });

--- a/app/views/cms-notification.html
+++ b/app/views/cms-notification.html
@@ -6,7 +6,7 @@
             tooltip="{{ !titleValid ? 'Title must be between 0 and 110 characters!' : '' }}"
             tooltip-placement="bottom">
           <onion-editor
-            ng-model="notification.title"
+            ng-model="cmsNotification.title"
             role="singleline"
             placeholder="Title"
             ng-class="{'bg-danger text-danger': !titleValid}">
@@ -14,7 +14,7 @@
         </div>
       </div>
       <div ng-show="!$parent.userIsSuperuser">
-        <div ng-bind-html="notification.title"></div>
+        <div ng-bind-html="cmsNotification.title"></div>
         <div class="header-post-date">{{ postDate.toDate() | date: 'MMM d, yyyy, h:mma' }}</div>
       </div>
     </h4>
@@ -22,11 +22,11 @@
   <div class="panel-body">
     <onion-editor
       ng-show="$parent.userIsSuperuser"
-      ng-model="notification.body"
+      ng-model="cmsNotification.body"
       role="multiline"
       placeholder="Write here">
     </onion-editor>
-    <span ng-show="!$parent.userIsSuperuser" ng-bind-html="notification.body"></span>
+    <span ng-show="!$parent.userIsSuperuser" ng-bind-html="cmsNotification.body"></span>
   </div>
   <div ng-show="$parent.userIsSuperuser" class="panel-footer clearfix">
     <div class="pull-right">
@@ -51,7 +51,7 @@
         <span
             datetime-selection-modal-opener
             ng-model="notifyEndDate"
-            modal-title="Choose Date to End Notifications"
+            modal-title="Choose Date to End CMS Notifications"
             ng-class="{'bg-danger text-danger': !notifyEndDateValid}">
           <span
               tooltip="{{ !notifyEndDateValid ? 'This date must occur after post date!' : '' }}"
@@ -65,12 +65,12 @@
       <div class="btn-group">
         <button
             class="btn btn-success btn-xs"
-            ng-disabled="!notificationDirty || !notificationValid"
-            ng-click="saveNotification()">
+            ng-disabled="!cmsNotificationDirty || !cmsNotificationValid"
+            ng-click="saveCmsNotification()">
           <i class="glyphicon glyphicon-save"></i>
           Save
         </button>
-        <button class="btn btn-danger btn-xs" ng-click="deleteNotification()">
+        <button class="btn btn-danger btn-xs" ng-click="deleteCmsNotification()">
           <i class="glyphicon glyphicon-remove"></i>
           Delete
         </button>

--- a/app/views/cms-notification.html
+++ b/app/views/cms-notification.html
@@ -51,7 +51,7 @@
         <span
             datetime-selection-modal-opener
             ng-model="notifyEndDate"
-            modal-title="Choose Date to End CMS Notifications"
+            modal-title="Choose Date to End CMS Alerts"
             ng-class="{'bg-danger text-danger': !notifyEndDateValid}">
           <span
               tooltip="{{ !notifyEndDateValid ? 'This date must occur after post date!' : '' }}"

--- a/app/views/cms-notifications.html
+++ b/app/views/cms-notifications.html
@@ -19,7 +19,7 @@
     <div ng-if="cmsNotifications.length > 0" class="col-md-12 panel-group">
       <cms-notification
           ng-repeat="cmsNotification in cmsNotifications"
-          cmsNotification="cmsNotification"
+          cms-notification="cmsNotification"
           class="cms-notification"></cms-notification>
     </div>
     <div ng-if="!userIsSuperuser && cmsNotifications.length < 1">

--- a/app/views/cms-notifications.html
+++ b/app/views/cms-notifications.html
@@ -1,29 +1,29 @@
 <nav-bar view="nav" ></nav-bar>
 
 <div id="content-wrapper" class="container cms-notifications">
-  <h2 class="heading">Notifications</h2>
+  <h2 class="heading">CMS Notifications</h2>
 
   <div class="row well well-sm">
     <div
         ng-if="userIsSuperuser"
         class="add-notification clearfix">
-      <span ng-if="notifications.length < 1" class="pull-left text-info">
+      <span ng-if="cmsNotifications.length < 1" class="pull-left text-info">
         <i class="glyphicon glyphicon-info-sign"></i>
-        No notifications yet, click "New Notification" to add one!
+        No CMS notifications yet, click "New CMS Notification" to add one!
       </span>
-      <button class="btn btn-success btn-xs pull-right" ng-click="newNotification()">
+      <button class="btn btn-success btn-xs pull-right" ng-click="newCmsNotification()">
         <i class="glyphicon glyphicon-plus"></i>
-        New Notification
+        New CMS Notification
       </button>
     </div>
-    <div ng-if="notifications.length > 0" class="col-md-12 panel-group">
+    <div ng-if="cmsNotifications.length > 0" class="col-md-12 panel-group">
       <cms-notification
-          ng-repeat="notification in notifications"
-          notification="notification"
+          ng-repeat="cmsNotification in cmsNotifications"
+          cmsNotification="cmsNotification"
           class="cms-notification"></cms-notification>
     </div>
-    <div ng-if="!userIsSuperuser && notifications.length < 1">
-      No notifications yet, check back soon!
+    <div ng-if="!userIsSuperuser && cmsNotifications.length < 1">
+      No CMS notifications yet, check back soon!
     </div>
   </div>
 

--- a/app/views/cms-notifications.html
+++ b/app/views/cms-notifications.html
@@ -1,7 +1,7 @@
 <nav-bar view="nav" ></nav-bar>
 
 <div id="content-wrapper" class="container cms-notifications">
-  <h2 class="heading">CMS Notifications</h2>
+  <h2 class="heading">CMS Alerts</h2>
 
   <div class="row well well-sm">
     <div
@@ -9,11 +9,11 @@
         class="add-notification clearfix">
       <span ng-if="cmsNotifications.length < 1" class="pull-left text-info">
         <i class="glyphicon glyphicon-info-sign"></i>
-        No CMS notifications yet, click "New CMS Notification" to add one!
+        No CMS notifications yet, click "New CMS Alert" to add one!
       </span>
       <button class="btn btn-success btn-xs pull-right" ng-click="newCmsNotification()">
         <i class="glyphicon glyphicon-plus"></i>
-        New CMS Notification
+        New CMS Alert
       </button>
     </div>
     <div ng-if="cmsNotifications.length > 0" class="col-md-12 panel-group">

--- a/app/views/cms-notify-container.html
+++ b/app/views/cms-notify-container.html
@@ -1,6 +1,6 @@
- <div ng-repeat="notification in notifications" class="cms-notify alert alert-info">
+ <div ng-repeat="cmsNotification in cmsNotifications" class="cms-notify alert alert-info">
   <i class="glyphicon glyphicon-info-sign"></i>
-  <span>New Update: {{ notification.title }}</span>
-  <a href="/cms/app/notifications/" class="alert-link">Learn More</a>
-  <a href="" class="alert-link" ng-click="dismissNotification(notification)">Dismiss</a>
+  <span>New Update: {{ cmsNotification.title }}</span>
+  <a href="/cms/app/cms-notifications/" class="alert-link">Learn More</a>
+  <a href="" class="alert-link" ng-click="dismissCmsNotification(cmsNotification)">Dismiss</a>
 </div>

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -15,7 +15,7 @@
         <active-nav href="/cms/app/list/" label="Content"></active-nav>
         <active-nav href="/cms/app/promotion/" label="Promotion" hide-if-forbidden options-url="/cms/api/v1/pzone/"></active-nav>
         <active-nav ng-show="current_user.data.is_manager" href="/cms/app/reporting/" label="Reporting"></active-nav>
-        <active-nav href="/cms/app/notifications/" label="Notifications"></active-nav>
+        <active-nav href="/cms/app/cms-notifications/" label="CMS Notifications"></active-nav>
         <active-nav href="/cms/app/campaigns/" label="Campaigns"></active-nav>
         <active-nav href="/cms/app/special-coverage/" label="Special Coverage"></active-nav>
         <active-nav href="/cms/app/section/" label="Sections"></active-nav>

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -15,7 +15,7 @@
         <active-nav href="/cms/app/list/" label="Content"></active-nav>
         <active-nav href="/cms/app/promotion/" label="Promotion" hide-if-forbidden options-url="/cms/api/v1/pzone/"></active-nav>
         <active-nav ng-show="current_user.data.is_manager" href="/cms/app/reporting/" label="Reporting"></active-nav>
-        <active-nav href="/cms/app/cms-notifications/" label="CMS Notifications"></active-nav>
+        <active-nav href="/cms/app/cms-notifications/" label="CMS Alerts"></active-nav>
         <active-nav href="/cms/app/campaigns/" label="Campaigns"></active-nav>
         <active-nav href="/cms/app/special-coverage/" label="Special Coverage"></active-nav>
         <active-nav href="/cms/app/section/" label="Sections"></active-nav>

--- a/test/spec/controllers/cms-notification.js
+++ b/test/spec/controllers/cms-notification.js
@@ -14,11 +14,11 @@ describe('Controller: CmsNotificationCtrl', function () {
     $httpBackend = _$httpBackend_;
     $scope = $rootScope.$new();
 
-    $httpBackend.expectGET('/cms/api/v1/notifications/').respond(mockApiData.notifications);
+    $httpBackend.expectGET('/cms/api/v1/cms_notifications/').respond(mockApiData.cmsNotifications);
 
-    CmsNotificationsApi.getList().then(function (notifications) {
-      $scope.notifications = notifications;
-      $scope.notification = $scope.notifications[0];
+    CmsNotificationsApi.getList().then(function (cmsNotifications) {
+      $scope.cmsNotifications = cmsNotifications;
+      $scope.cmsNotification = $scope.cmsNotifications[0];
     });
 
     $httpBackend.flush();
@@ -29,11 +29,11 @@ describe('Controller: CmsNotificationCtrl', function () {
       CmsNotificationsApi: CmsNotificationsApi
     });
 
-    sinon.spy($scope.notification, 'put');
-    sinon.spy($scope.notification, 'remove');
-    sinon.spy($scope.notifications, 'post');
+    sinon.spy($scope.cmsNotification, 'put');
+    sinon.spy($scope.cmsNotification, 'remove');
+    sinon.spy($scope.cmsNotifications, 'post');
 
-    $scope.notificationDirty = false;
+    $scope.cmsNotificationDirty = false;
 
     $scope.$parent.userIsSuperuser = true;
 
@@ -41,16 +41,16 @@ describe('Controller: CmsNotificationCtrl', function () {
 
   it('should have a scope level variable to track if a notification is dirty', function () {
 
-    expect($scope.notificationDirty).to.equal(false);
+    expect($scope.cmsNotificationDirty).to.equal(false);
 
     // start watch
     $scope.$apply();
     // make mod
-    $scope.notification.title = 'Some New Title';
+    $scope.cmsNotification.title = 'Some New Title';
     // fire watch again, which should recognize the change now
     $scope.$apply();
 
-    expect($scope.notificationDirty).to.equal(true);
+    expect($scope.cmsNotificationDirty).to.equal(true);
 
   });
 
@@ -58,50 +58,50 @@ describe('Controller: CmsNotificationCtrl', function () {
 
     // set up mock save and deletes for this block of tests
     beforeEach(inject(function ($q) {
-      $scope.$parent.$saveNotification = function () {
+      $scope.$parent.$saveCmsNotification = function () {
         var saveDefer = $q.defer(),
             savePromise = saveDefer.promise;
         saveDefer.resolve({});
         return savePromise;
       };
-      $scope.$parent.$deleteNotification = function () {
+      $scope.$parent.$deleteCmsNotification = function () {
         var deleteDefer = $q.defer(),
             deletePromise = deleteDefer.promise;
         deleteDefer.resolve();
         return deletePromise;
       };
 
-      sinon.spy($scope.$parent, '$saveNotification');
-      sinon.spy($scope.$parent, '$deleteNotification');
+      sinon.spy($scope.$parent, '$saveCmsNotification');
+      sinon.spy($scope.$parent, '$deleteCmsNotification');
 
     }));
 
     it('should not be able to save if no changes have been made', function () {
 
-      $scope.saveNotification();
+      $scope.saveCmsNotification();
       $scope.$apply();
 
-      expect($scope.$parent.$saveNotification).not.to.have.been.called;
+      expect($scope.$parent.$saveCmsNotification).not.to.have.been.called;
 
     });
 
     it('should have a function to save itself using the parent scope\'s save function', function () {
 
-      $scope.notificationDirty = true;
+      $scope.cmsNotificationDirty = true;
 
-      $scope.saveNotification();
+      $scope.saveCmsNotification();
       $scope.$apply();
 
-      expect($scope.$parent.$saveNotification).to.have.been.called;
-      expect($scope.notificationDirty).to.equal(false);
+      expect($scope.$parent.$saveCmsNotification).to.have.been.called;
+      expect($scope.cmsNotificationDirty).to.equal(false);
 
     });
 
     it('should have a function to delete itself using the parent scope\'s remove function', function () {
 
-      $scope.deleteNotification();
+      $scope.deleteCmsNotification();
 
-      expect($scope.$parent.$deleteNotification).to.have.been.called;
+      expect($scope.$parent.$deleteCmsNotification).to.have.been.called;
 
     });
 
@@ -109,16 +109,16 @@ describe('Controller: CmsNotificationCtrl', function () {
 
       $scope.$parent.userIsSuperuser = false;
 
-      $scope.notification.editable = false;
-      $scope.notificationDirty = true;
-      $scope.notificationValid = true;
+      $scope.cmsNotification.editable = false;
+      $scope.cmsNotificationDirty = true;
+      $scope.cmsNotificationValid = true;
 
-      $scope.saveNotification();
-      $scope.deleteNotification();
+      $scope.saveCmsNotification();
+      $scope.deleteCmsNotification();
       $scope.$apply();
 
-      expect($scope.$parent.$saveNotification).not.to.have.been.called;
-      expect($scope.$parent.$deleteNotification).not.to.have.been.called;
+      expect($scope.$parent.$saveCmsNotification).not.to.have.been.called;
+      expect($scope.$parent.$deleteCmsNotification).not.to.have.been.called;
 
     });
 

--- a/test/spec/controllers/cms-notifications.js
+++ b/test/spec/controllers/cms-notifications.js
@@ -34,7 +34,7 @@ describe('Controller: CmsNotificationsCtrl', function () {
     beforeEach(inject(function ($rootScope, $controller, CmsNotificationsApi, $window,
                                 mockApiData, CurrentUser) {
 
-      $httpBackend.expectGET('/cms/api/v1/notifications/').respond(mockApiData.notifications);
+      $httpBackend.expectGET('/cms/api/v1/cms_notifications/').respond(mockApiData.cmsNotifications);
 
       CmsNotificationsCtrl = $controller('CmsNotificationsCtrl', {
         $window: $window,
@@ -50,79 +50,79 @@ describe('Controller: CmsNotificationsCtrl', function () {
 
     it('should initialize with notifications from backend', function () {
 
-      expect($scope.notifications[0].title).to.equal('We\'ve Made An Update!');
+      expect($scope.cmsNotifications[0].title).to.equal('We\'ve Made An Update!');
 
     });
 
     it('should provide a function to add new notifications to top of notifications list', function () {
 
-      var prevLength = $scope.notifications.length;
+      var prevLength = $scope.cmsNotifications.length;
 
-      $scope.newNotification();
+      $scope.newCmsNotification();
 
-      var newLength = $scope.notifications.length,
-          newNotification = $scope.notifications[0];
+      var newLength = $scope.cmsNotifications.length,
+          newCmsNotification = $scope.cmsNotifications[0];
 
       expect(newLength).to.equal(prevLength + 1);
 
       // we only care about ensuring that there's no post / notify end date for new posts
-      expect(newNotification.post_date).to.equal(null);
-      expect(newNotification.notify_end_date).to.equal(null);
+      expect(newCmsNotification.post_date).to.equal(null);
+      expect(newCmsNotification.notify_end_date).to.equal(null);
 
     });
 
     it('should provide a function to save a notification', function () {
 
-      var notificationToSave = $scope.newNotification(),
+      var cmsNotificationToSave = $scope.newCmsNotification(),
           newPostDate = moment('2014-09-25T16:00:00-0500'),
           newNotifyEndDate = moment('2014-09-28T16:00:00-0500');
 
-      notificationToSave.title = 'A New Notification';
-      notificationToSave.body = 'Whatever balhb alhblahb.';
-      notificationToSave.post_date = newPostDate;
-      notificationToSave.notify_end_date = newNotifyEndDate;
+      cmsNotificationToSave.title = 'A New Notification';
+      cmsNotificationToSave.body = 'Whatever balhb alhblahb.';
+      cmsNotificationToSave.post_date = newPostDate;
+      cmsNotificationToSave.notify_end_date = newNotifyEndDate;
 
-      $httpBackend.expectPOST('/cms/api/v1/notifications/').respond(200, notificationToSave);
+      $httpBackend.expectPOST('/cms/api/v1/cms_notifications/').respond(200, cmsNotificationToSave);
 
-      var notificationSaved = null;
-      $scope.$saveNotification(notificationToSave).then(function (notification) {
-        notificationSaved = notification;
+      var cmsNotificationSaved = null;
+      $scope.$saveCmsNotification(cmsNotificationToSave).then(function (cmsNotification) {
+        cmsNotificationSaved = cmsNotification;
       });
 
       $httpBackend.flush();
       $scope.$apply();
 
-      expect(notificationSaved.getRestangularUrl).not.to.be.undefined;
-      expect(notificationSaved.title).to.equal(notificationToSave.title);
-      expect(notificationSaved.post_date.valueOf()).to.equal(newPostDate.valueOf());
-      expect(notificationSaved.notify_end_date.valueOf()).to.equal(newNotifyEndDate.valueOf());
+      expect(cmsNotificationSaved.getRestangularUrl).not.to.be.undefined;
+      expect(cmsNotificationSaved.title).to.equal(cmsNotificationToSave.title);
+      expect(cmsNotificationSaved.post_date.valueOf()).to.equal(newPostDate.valueOf());
+      expect(cmsNotificationSaved.notify_end_date.valueOf()).to.equal(newNotifyEndDate.valueOf());
 
-      notificationSaved.title = 'Updated Title';
-      notificationSaved.id = 0;
+      cmsNotificationSaved.title = 'Updated Title';
+      cmsNotificationSaved.id = 0;
 
-      $httpBackend.expectPUT('/cms/api/v1/notifications/' + notificationSaved.id + '/').respond(200, notificationSaved);
+      $httpBackend.expectPUT('/cms/api/v1/cms_notifications/' + cmsNotificationSaved.id + '/').respond(200, cmsNotificationSaved);
 
-      var notificationUpdated = null;
-      $scope.$saveNotification(notificationSaved).then(function (notification) {
-        notificationUpdated = notification;
+      var cmsNotificationUpdated = null;
+      $scope.$saveCmsNotification(cmsNotificationSaved).then(function (cmsNotification) {
+        cmsNotificationUpdated = cmsNotification;
       });
 
       $httpBackend.flush();
       $scope.$apply();
 
-      expect(notificationUpdated.title).to.equal(notificationSaved.title);
+      expect(cmsNotificationUpdated.title).to.equal(cmsNotificationSaved.title);
 
     });
 
     it('should provide a function to remove a notification', function () {
 
-      var notificationToDelete = $scope.notifications[0],
+      var cmsNotificationToDelete = $scope.cmsNotifications[0],
           deleted = false,
-          oldLength = $scope.notifications.length;
+          oldLength = $scope.cmsNotifications.length;
 
-      $httpBackend.expectDELETE('/cms/api/v1/notifications/0/').respond(200);
+      $httpBackend.expectDELETE('/cms/api/v1/cms_notifications/0/').respond(200);
 
-      $scope.$deleteNotification(notificationToDelete).then(function () {
+      $scope.$deleteCmsNotification(cmsNotificationToDelete).then(function () {
         deleted = true;
       });
 
@@ -130,7 +130,7 @@ describe('Controller: CmsNotificationsCtrl', function () {
       $scope.$apply();
 
       expect(deleted).to.equal(true);
-      expect($scope.notifications.length).to.equal(oldLength - 1);
+      expect($scope.cmsNotifications.length).to.equal(oldLength - 1);
 
     });
 
@@ -153,7 +153,7 @@ describe('Controller: CmsNotificationsCtrl', function () {
     beforeEach(inject(function ($rootScope, $controller, CmsNotificationsApi, $window, moment, CurrentUser) {
 
       var today = moment();
-      $httpBackend.expectGET('/cms/api/v1/notifications/').respond([
+      $httpBackend.expectGET('/cms/api/v1/cms_notifications/').respond([
         {
           id: 0,
           title: 'I Should be Listed',
@@ -180,8 +180,8 @@ describe('Controller: CmsNotificationsCtrl', function () {
 
     it('should not show notifications that aren\'t editable if their post date is in the future', function () {
 
-      expect($scope.notifications.length).to.equal(1);
-      expect($scope.notifications[0].id).to.equal(0);
+      expect($scope.cmsNotifications.length).to.equal(1);
+      expect($scope.cmsNotifications[0].id).to.equal(0);
 
     });
 


### PR DESCRIPTION
Prep for new "Notification" support by renaming old "CMS Notifications" to avoid naming collisions.

- [x] Internal: Rename "Notification" to "CMS Notification" (and related `cmsNotifcation`/`CmsNotification` casing)
- [x] Public-facing: Rebrand "CMS Notifications" as "CMS Alerts"

This is a little confusing, but due to Notification launch time constraints, simplest to use internal names "cms notifications" and change to "cms alerts" as followup Tech Debt.

I'm open to suggestions if you think there's a better way to manage this. 