### PR TITLE
Super feature fix ordering on remove

### DIFF
--- a/app/components/super-features/super-features-relations/super-features-relations.html
+++ b/app/components/super-features/super-features-relations/super-features-relations.html
@@ -99,7 +99,7 @@
         <form
             ng-submit="
               $event.preventDefault();
-              moveRelation($index, relation.ordering - 1);
+              moveRelation($index, relation.ordering - 1, true);
               getOrderingForm(relation).$setPristine();
             "
             name="{{ makeOrderingFormName(relation) }}"
@@ -124,7 +124,7 @@
               transactionsLocked() ||
               $index === 0
             "
-            ng-click="moveRelation($index, $index - 1)">
+            ng-click="moveRelation($index, $index - 1, true)">
           <i class="fa fa-chevron-up"></i>
         </button>
         <button
@@ -133,7 +133,7 @@
               transactionsLocked() ||
               $index === relations.length - 1
             "
-            ng-click="moveRelation($index, $index + 1)">
+            ng-click="moveRelation($index, $index + 1, true)">
           <i class="fa fa-chevron-down"></i>
         </button>
       </div>
@@ -143,17 +143,17 @@
         ng-hide="panelClosed"
         class="accordion-list-item-content">
 
-      <form name="{{ makeRelationFormName(relation) }}">
+      <div class="super-features-relations-input-container">
+        <button
+            send-to-editor-modal-opener
+            modal-article="article"
+            class="btn btn-sm btn-info">
+          <i class="fa fa-paper-plane"></i>
+          <span>Send To Editors...</span>
+        </button>
+      </div>
 
-        <div class="super-features-relations-input-container">
-          <button
-              send-to-editor-modal-opener
-              modal-article="article"
-              class="btn btn-sm btn-info">
-            <i class="fa fa-paper-plane"></i>
-            <span>Send To Editors...</span>
-          </button>
-        </div>
+      <form name="{{ makeRelationFormName(relation) }}">
 
         <div class="super-features-relations-input-container">
           <label

--- a/app/components/super-features/super-features-relations/super-features-relations.js
+++ b/app/components/super-features/super-features-relations/super-features-relations.js
@@ -107,31 +107,34 @@ angular.module('bulbs.cms.superFeatures.relations', [
               return $q.reject();
             };
           };
+          var reorder = function (operation) {
 
-          scope.moveRelation = transaction(function (fromIndex, toIndex) {
+            return function () {
+              var funcArgs = arguments;
 
-            // do transformation on a copy first, save that then after successful
-            //  request, apply transformation to actual list
-            var payload = scope.relations.map(function (relation) {
-              return _.pick(relation, 'id', 'ordering');
-            });
-
-            Utils.moveTo(payload, fromIndex, toIndex, true);
-            normalizeOrderings(payload);
-
-            return SuperFeaturesApi.updateSuperFeatureRelationsOrdering(
-              scope.article.id,
-              payload
-            )
-              .then(function () {
-                Utils.moveTo(scope.relations, fromIndex, toIndex, true);
-                normalizeOrderings(scope.relations);
-              })
-              .catch(function (response) {
-                var message = 'An error occurred attempting to reorder a child!';
-                scope.reportError(message, { response: response });
+              var payload = scope.relations.map(function (relation) {
+                return _.pick(relation, 'id', 'ordering');
               });
-          });
+
+              operation.bind(null, payload).apply(null, funcArgs);
+              normalizeOrderings(payload)
+
+              return SuperFeaturesApi.updateSuperFeatureRelationsOrdering(
+                scope.article.id,
+                payload
+              )
+                .then(function () {
+                  operation.bind(null, scope.relations).apply(null, funcArgs);
+                  normalizeOrderings(scope.relations);
+                })
+                .catch(function (response) {
+                  var message = 'An error occurred attempting to reorder a child!';
+                  scope.reportError(message, { response: response });
+                });
+            };
+          };
+
+          scope.moveRelation = transaction(reorder(Utils.moveTo));
 
           scope.addRelation = transaction(function (title) {
 
@@ -189,8 +192,7 @@ angular.module('bulbs.cms.superFeatures.relations', [
             return SuperFeaturesApi.deleteSuperFeature(relation)
               .then(function () {
                 var index = scope.relations.indexOf(relation);
-                Utils.removeFrom(scope.relations, index);
-                normalizeOrderings(scope.relations);
+                reorder(Utils.removeFrom)(index);
               })
               .catch(function (response) {
                 var titleDisplay = relation.title ? '"' + relation.title + '"' : 'a relation';

--- a/app/components/super-features/super-features-relations/super-features-relations.js
+++ b/app/components/super-features/super-features-relations/super-features-relations.js
@@ -117,7 +117,7 @@ angular.module('bulbs.cms.superFeatures.relations', [
               });
 
               operation.bind(null, payload).apply(null, funcArgs);
-              normalizeOrderings(payload)
+              normalizeOrderings(payload);
 
               return SuperFeaturesApi.updateSuperFeatureRelationsOrdering(
                 scope.article.id,

--- a/app/components/super-features/super-features-relations/super-features-relations.tests.js
+++ b/app/components/super-features/super-features-relations/super-features-relations.tests.js
@@ -110,7 +110,6 @@ describe('Directive: superFeaturesRelations', function () {
       var title = 'test title';
 
       addButton.trigger('click');
-      scope.$digest();
       addButton.isolateScope().modalOnOk({ title: title });
       createSuperFeatureDeferred.resolve(relation);
       scope.$digest();
@@ -242,7 +241,6 @@ describe('Directive: superFeaturesRelations', function () {
       var scope = element.scope();
 
       addButton.trigger('click');
-      scope.$digest();
       addButton.isolateScope().modalOnOk();
       scope.$digest();
 
@@ -311,9 +309,9 @@ describe('Directive: superFeaturesRelations', function () {
       var scope = element.scope();
 
       deleteButton.trigger('click');
-      scope.$digest();
       deleteButton.isolateScope().modalOnOk();
       deleteSuperFeatureDeferred.resolve();
+      updateSuperFeatureRelationsOrderingDeferred.resolve();
       scope.$digest();
 
       expect(SuperFeaturesApi.deleteSuperFeature.calledOnce).to.equal(true);
@@ -328,7 +326,6 @@ describe('Directive: superFeaturesRelations', function () {
       var scope = element.scope();
 
       deleteButton.trigger('click');
-      scope.$digest();
       deleteButton.isolateScope().modalOnOk();
       scope.$digest();
 
@@ -346,7 +343,6 @@ describe('Directive: superFeaturesRelations', function () {
       var scope = element.scope();
 
       deleteButton.trigger('click');
-      scope.$digest();
       deleteButton.isolateScope().modalOnOk();
       deleteSuperFeatureDeferred.reject();
       scope.$digest();
@@ -364,7 +360,6 @@ describe('Directive: superFeaturesRelations', function () {
       var saveButton = element.find('button[ng-click="saveRelation(relation)"]');
 
       deleteButton.trigger('click');
-      element.scope().$digest();
       deleteButton.isolateScope().modalOnOk();
       saveButton.trigger('click');
 
@@ -434,7 +429,6 @@ describe('Directive: superFeaturesRelations', function () {
 
       updateButton.trigger('click');
       deleteButton.trigger('click');
-      element.scope().$digest();
       deleteButton.isolateScope().modalOnOk();
 
       expect(SuperFeaturesApi.deleteSuperFeature.called).to.equal(false);
@@ -465,7 +459,7 @@ describe('Directive: superFeaturesRelations', function () {
 
       beforeEach(function () {
         element = digest(html);
-        ups = element.find('button[ng-click="moveRelation($index, $index - 1)"]');
+        ups = element.find('button[ng-click="moveRelation($index, $index - 1, true)"]');
       });
 
       it('should allow moving a relation up', function () {
@@ -501,7 +495,7 @@ describe('Directive: superFeaturesRelations', function () {
 
       beforeEach(function () {
         element = digest(html);
-        downs = element.find('button[ng-click="moveRelation($index, $index + 1)"]');
+        downs = element.find('button[ng-click="moveRelation($index, $index + 1, true)"]');
       });
 
       it('should allow moving a relation down', function () {

--- a/app/mocks/api.js
+++ b/app/mocks/api.js
@@ -77,6 +77,8 @@ angular.module('bulbsCmsApp.mockApi', [
         return [201, newData];
       });
 
+    $httpBackend.whenDELETE(/\/cms\/api\/v1\/content\/\d+\/?/).respond(204);
+
     var trashRegex = /\/cms\/api\/v1\/content\/\d+\/trash\//;
     $httpBackend.when('POST', trashRegex).respond(mockApiData['content.trash.response']);
     $httpBackend.when('OPTIONS', trashRegex).respond(mockApiData['content.trash.response']);


### PR DESCRIPTION
Removing an item wasn't properly updating `ordering` on relations in the backend, so need to send an ordering request after removing an item.

Split up the code into a `reorder` function which gets wrapped in a transaction during `moveRelation`, but is used without a transaction during `removeRelation` so the UI lock allows it to run.