### PR TITLE
remove urlify on the article slug

### DIFF
--- a/app/scripts/controllers/contentedit.js
+++ b/app/scripts/controllers/contentedit.js
@@ -247,10 +247,6 @@ angular.module('bulbsCmsApp')
     };
 
     $scope.postValidationSaveArticle = function () {
-      if ($scope.article.status !== 'Published') {
-        $scope.article.slug = $window.URLify($scope.article.title, 50);
-      }
-
       var params = {};
       if ($routeParams.id === 'new') {
         params['doctype'] = $scope.article.polymorphic_ctype;


### PR DESCRIPTION
@kand @spra85 @collin  @mparent61 @benghaziboy this is causing problems with the guide to home ownership, where the slug will be changed when changes to the SF are made in the CMS. we should be fine to remove this because of https://github.com/theonion/django-bulbs/blob/master/bulbs/content/models.py#L387-L388 but we could also leave this and check if the type is SF, since that’s the only content item that requires specific slugs