### PR TITLE
type check on article slugification

### DIFF
--- a/app/scripts/controllers/contentedit.js
+++ b/app/scripts/controllers/contentedit.js
@@ -247,6 +247,11 @@ angular.module('bulbsCmsApp')
     };
 
     $scope.postValidationSaveArticle = function () {
+      if ($scope.article.status !== 'Published' &&
+          $scope.article.polymorphic_ctype !== CmsConfig.getSuperFeaturesType()) {
+        $scope.article.slug = $window.URLify($scope.article.title, 50);
+      }
+
       var params = {};
       if ($routeParams.id === 'new') {
         params['doctype'] = $scope.article.polymorphic_ctype;


### PR DESCRIPTION
@kand @daytonn @collin @MelizzaP @spra85 reverting this change and adding a type check for super features. previously, if an editor typed in a garbage or working title, that slug would then become permanent. this hasn’t been a problem thus far because onion has titles written in advance