### PR TITLE
Live Blogs - additional styling and ui elements

### DIFF
--- a/app/components/live-blog/live-blog-entries/live-blog-entries.html
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.html
@@ -135,6 +135,17 @@
         <div class="accordion-list-item-meta-tools">
 
           <button
+              ng-click="saveEntry(entry)"
+              ng-disabled="
+                transactionsLocked() ||
+                getEntryForm(entry).$pristine
+              "
+              class="btn btn-success btn-sm">
+            <i class="fa fa-floppy-o"></i>
+            <span>SAVE</span>
+          </button>
+
+          <button
               ng-disabled="transactionsLocked()"
               confirmation-modal-opener
               modal-body="Are you sure you want to delete {{ entry.headline ? '\'' + entry.headline + '\'' : 'this entry' }}?"

--- a/app/components/live-blog/live-blog-entries/live-blog-entries.html
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.html
@@ -62,10 +62,7 @@
       <div class="accordion-list-item-meta-tools">
         <button
             ng-click="saveEntry(entry)"
-            ng-disabled="
-              transactionsLocked() ||
-              getEntryForm(entry).$pristine
-            "
+            ng-disabled="isEntryFormSaveDisabled(entry)"
             class="btn btn-success btn-xs">
           <i class="fa fa-floppy-o"></i>
           <span>Save</span>
@@ -136,10 +133,7 @@
 
           <button
               ng-click="saveEntry(entry)"
-              ng-disabled="
-                transactionsLocked() ||
-                getEntryForm(entry).$pristine
-              "
+              ng-disabled="isEntryFormSaveDisabled(entry)"
               class="btn btn-success btn-sm">
             <i class="fa fa-floppy-o"></i>
             <span>SAVE</span>

--- a/app/components/live-blog/live-blog-entries/live-blog-entries.js
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.js
@@ -76,6 +76,9 @@ angular.module('bulbs.cms.liveBlog.entries', [
             scope.wrapperForm[name] = {};
             return scope.wrapperForm[name];
           };
+          scope.isEntryFormSaveDisabled = function (entry) {
+            return scope.transactionsLocked() || scope.getEntryForm(entry).$pristine;
+          };
 
           var lock = Utils.buildLock();
           scope.transactionsLocked = lock.isLocked;

--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,7 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="bower_components/angular-bootstrap-datetimepicker/src/css/datetimepicker.css" />
+    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
     <link rel="stylesheet" href="bower_components/jcrop/css/jquery.Jcrop.css" />
     <link rel="stylesheet" href="bower_components/onion-editor/build/editor-main.css" />
     <link rel="stylesheet" href="bower_components/pnotify/pnotify.core.css" />

--- a/app/styles/_sizing.less
+++ b/app/styles/_sizing.less
@@ -13,6 +13,7 @@
 @interface-border-radius: 4px;
 @interface-internal-spacing: 10px;
 @interface-row-margin: @interface-internal-spacing * 3;
+@interface-row-margin-large: @interface-internal-spacing * 5;
 
 @interface-font-size-1: 10px;
 @interface-font-size-2: 12px;

--- a/app/styles/mixins/_mixin-accordion-list.less
+++ b/app/styles/mixins/_mixin-accordion-list.less
@@ -36,7 +36,9 @@
           font-weight: bold;
           margin: 5px;
           max-width: 33%;
+          min-width: 10%;
           overflow-x: hidden;
+          text-align: left;
           text-overflow: ellipsis;
           white-space: nowrap;
 

--- a/app/styles/mixins/_mixin-accordion-list.less
+++ b/app/styles/mixins/_mixin-accordion-list.less
@@ -15,8 +15,8 @@
     > li {
       background: @interface-color-gray-3;
       border-radius: @interface-border-radius;
-      border: solid 1px @interface-color-gray-2;
-      margin-bottom: 20px;
+      border: solid 2px @interface-color-near-black;
+      margin-bottom: @interface-row-margin-large;
 
       .accordion-list-item-meta {
         padding: 10px;


### PR DESCRIPTION
Provides styling updates to live blog interface.

**Release Type**: _patch_
Updates are only markup and styling, nothing has been deleted or changed in a way that is a major feature or breaking change.

**New**

1. Added another save button for live blog entries inside the accordion element next to the delete button.

2. Added `@interface-row-margin-large` variable to less sizing variables. Another row margin, but larger, used now only for margin between live blog entries.

**Updates**

1. Thicker, darker border around live blog entries for added clarity.

2. Using `@interface-row-marign-large` between entires in list for added clarity.