### PR TITLE
Allow html in list page cell contents and breadcrumbs

### DIFF
--- a/app/components/breadcrumb/breadcrumb.html
+++ b/app/components/breadcrumb/breadcrumb.html
@@ -5,14 +5,14 @@
 
 <span ng-repeat="link in linksList track by $index">
   <span
+      ng-bind-html="renderValue(link.label)"
       ng-if="!link.href"
       class="breadcrumb-link-hrefless">
-    {{ renderValue(link.label) }}
   </span>
   <a
+      ng-bind-html="renderValue(link.label)"
       ng-if="link.href"
       href="{{ renderValue(link.href) }}">
-    {{ renderValue(link.label) }}
   </a>
   <i
       ng-if="!$last"

--- a/app/components/breadcrumb/breadcrumb.js
+++ b/app/components/breadcrumb/breadcrumb.js
@@ -5,15 +5,15 @@ angular.module('bulbs.cms.breadcrumb', [
   'bulbs.cms.superFeatures.api'
 ])
   .directive('breadcrumb', [
-    'CmsConfig',
-    function (CmsConfig) {
+    '$sce', 'CmsConfig',
+    function ($sce, CmsConfig) {
       return {
         scope: {
           linksList: '='
         },
         link: function (scope, element, attrs) {
           scope.renderValue = function (value) {
-            return angular.isFunction(value) ? value() : value;
+            return $sce.trustAsHtml(angular.isFunction(value) ? value() : value);
           };
         },
         templateUrl: CmsConfig.buildComponentPath(

--- a/app/components/breadcrumb/breadcrumb.tests.js
+++ b/app/components/breadcrumb/breadcrumb.tests.js
@@ -113,4 +113,19 @@ describe('Directive: superFeatureBreadcrumb', function () {
 
     expect(element.find('a').eq(0).attr('href')).to.have.string(href);
   });
+
+  it('should render html', function () {
+    $parentScope.links = [{
+      label: 'some <em>thing</em> to render'
+    }, {
+      label: 'another <em>thing</em> to render',
+      href: function () {
+        return 'some/link';
+      }
+    }];
+
+    var element = digest('<breadcrumb links-list="links"></breadcrumb>');
+
+    expect(element.find('em').length).to.equal(2);
+  });
 });

--- a/app/components/super-features/super-features-api/super-features-api.js
+++ b/app/components/super-features/super-features-api/super-features-api.js
@@ -8,8 +8,8 @@ angular.module('bulbs.cms.superFeatures.api', [
   'moment'
 ])
   .service('SuperFeaturesApi', [
-    '_', '$http', 'CmsConfig', 'dateTimeFormatFilter', 'moment', 'Utils',
-    function (_, $http, CmsConfig, dateTimeFormatFilter, moment, Utils) {
+    '_', '$http', '$sce', 'CmsConfig', 'dateTimeFormatFilter', 'moment', 'Utils',
+    function (_, $http, $sce, CmsConfig, dateTimeFormatFilter, moment, Utils) {
 
       var superFeatureEndpoint = CmsConfig.buildApiUrlRoot.bind(null, 'super-feature');
       var contentEndpoint = CmsConfig.buildApiUrlRoot.bind(null, 'content');
@@ -54,7 +54,10 @@ angular.module('bulbs.cms.superFeatures.api', [
         },
         fields: [{
           title: 'Super Feature Name',
-          sorts: 'title'
+          sorts: 'title',
+          content: function (superFeature) {
+            return $sce.trustAsHtml(superFeature.title);
+          }
         }, {
           title: 'Total Nested Pages',
           content: 'children_count'

--- a/app/index.html
+++ b/app/index.html
@@ -15,7 +15,6 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="bower_components/angular-bootstrap-datetimepicker/src/css/datetimepicker.css" />
-    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
     <link rel="stylesheet" href="bower_components/jcrop/css/jquery.Jcrop.css" />
     <link rel="stylesheet" href="bower_components/onion-editor/build/editor-main.css" />
     <link rel="stylesheet" href="bower_components/pnotify/pnotify.core.css" />

--- a/app/mocks/api-mock-data.js
+++ b/app/mocks/api-mock-data.js
@@ -431,7 +431,7 @@ angular.module('bulbsCmsApp.mockApi.data', [])
         }
       }, {
         id: 13,
-        title: 'Guide to My Favorite Animals',
+        title: 'Guide to My <em>Favorite</em> Animals',
         slug: 'my-favorite-animals',
         polymorphic_ctype: 'core_super_feature_type',
         superfeature_type: 'GUIDE_TO_ANIMALZ_PARENT',

--- a/app/shared/list-page/list-page.html
+++ b/app/shared/list-page/list-page.html
@@ -95,8 +95,9 @@
     </thead>
     <tbody>
       <tr ng-repeat="item in $list">
-        <td ng-repeat="field in fields">
-          {{ field.evaluate(item) }}
+        <td
+            ng-repeat="field in fields"
+            ng-bind-html="field.evaluate(item)">
         </td>
         <td>
           <a

--- a/app/shared/non-restmod-list-page/non-restmod-list-page.html
+++ b/app/shared/non-restmod-list-page/non-restmod-list-page.html
@@ -78,8 +78,9 @@
     </thead>
     <tbody>
       <tr ng-repeat="item in items">
-        <td ng-repeat="field in modelFields()">
-          {{ cellContents(item, field) }}
+        <td
+            ng-repeat="field in modelFields()"
+            ng-bind-html="cellContents(item, field)">
         </td>
         <td>
           <a


### PR DESCRIPTION
Prepping list pages and breadcrumbs for AVC's html-laden titles.

**Release Type**: _patch_
No large-scale new features, no breaking changes. Only a small update to the way cell contents in list pages and breadcrumbs are rendered.

**Updates**

1. `breadcrumb` component will render html in link labels.

2.  `SuperFeaturesApi` will attempt to render title as html for list pages.

3. `list-page` and `non-restmod-list-page` will attempt to evaluate html in cell contents.

