### PR TITLE
Super Features - check that article has a default_child_type before rendering relations

### DIFF
--- a/app/components/super-features/super-features-edit/super-features-edit.html
+++ b/app/components/super-features/super-features-edit/super-features-edit.html
@@ -68,6 +68,6 @@
 </div>
 
 <super-features-relations
-    ng-if="!article.parent"
+    ng-if="!article.parent && article.default_child_type"
     article="article">
 </super-features-relations>


### PR DESCRIPTION
Super features without a sub type shouldn't render the relations component.

**Release Type**: _patch_
No new major features, no breaking changes.

**Updates**

1. `super-features-edit` directive no longer renders `super-features-relations` component if `article` on parent scope doesn't have a `default_child_type` property set.