### PR TITLE
Condense cms navs

### DIFF
--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -9,6 +9,8 @@
 @interface-color-gray-3: #f6f6f6;
 @interface-color-gray-4: #dddddd;
 @interface-color-gray-5: #a6a6a6;
+@interface-color-gray-6: #333333;
+@interface-color-gray-7: #777777;
 @interface-color-water: #3a85bf;
 @interface-color-water-2: #d9edf7;
 @interface-color-success: #5fbd00;

--- a/app/styles/bootstrap-navbar-override.less
+++ b/app/styles/bootstrap-navbar-override.less
@@ -127,15 +127,7 @@
 .navbar-toggle:focus {
   outline: none;
 }
-.navbar-toggle .icon-bar {
-  display: block;
-  width: 22px;
-  height: 2px;
-  border-radius: 1px;
-}
-.navbar-toggle .icon-bar + .icon-bar {
-  margin-top: 4px;
-}
+
 @media (min-width: 768px) {
   .navbar-toggle {
     display: none;
@@ -338,9 +330,6 @@
 .navbar-default .navbar-toggle:focus {
   background-color: #dddddd;
 }
-.navbar-default .navbar-toggle .icon-bar {
-  background-color: #888888;
-}
 .navbar-default .navbar-collapse,
 .navbar-default .navbar-form {
   border-color: #e7e7e7;
@@ -420,9 +409,6 @@
 .navbar-inverse .navbar-toggle:hover,
 .navbar-inverse .navbar-toggle:focus {
   background-color: #333333;
-}
-.navbar-inverse .navbar-toggle .icon-bar {
-  background-color: #ffffff;
 }
 .navbar-inverse .navbar-collapse,
 .navbar-inverse .navbar-form {

--- a/app/styles/bootstrap-navbar-override.less
+++ b/app/styles/bootstrap-navbar-override.less
@@ -97,7 +97,7 @@
 }
 .navbar-brand {
   float: left;
-  padding: 7.5px 15px;
+  padding: 10px 15px;
   font-size: 18px;
   line-height: 20px;
   height: 35px;
@@ -180,8 +180,8 @@
     float: left;
   }
   .navbar-nav > li > a {
-    padding-top: 7.5px;
-    padding-bottom: 7.5px;
+    padding-top: 10px;
+    padding-bottom: 10px;
   }
   .navbar-nav.navbar-right:last-child {
     margin-right: -15px;
@@ -283,8 +283,8 @@
   margin-bottom: 6.5px;
 }
 .navbar-text {
-  margin-top: 7.5px;
-  margin-bottom: 7.5px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 @media (min-width: 768px) {
   .navbar-text {

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -153,29 +153,34 @@ td.author { max-width: 150px; }
         button.go{ width: 100%; margin-top: 5px; } } }
 
 nav.navbar {
-  @icon-spacing: 5px;
 
   .dropdown {
 
     button.dropdown-toggle {
       .mixin-button-no-style();
 
-      padding: @interface-internal-spacing;
+      color: @interface-color-gray-7;
+      padding: @interface-internal-spacing 15px;
+      text-align: left;
 
       &[aria-expanded="true"] {
         background-color: @interface-color-gray-2;
       }
 
-      span {
-        margin-right: @icon-spacing;
+      &:hover {
+        color: @interface-color-gray-6;
       }
-    }
 
-    ul.dropdown-menu {
+      ul.dropdown-menu li {
 
-      li.active a {
-        background-color: @interface-color-gray-2;
-        color: inherit;
+        &.active a {
+          background-color: @interface-color-gray-2;
+          color: inherit;
+        }
+
+        a {
+          padding: @interface-internal-spacing/2 @interface-internal-spacing;
+        }
       }
     }
   }
@@ -187,7 +192,7 @@ nav.navbar {
     padding: 10px;
   }
 
-  ul li {
+  ul.navbar-nav > li {
 
     &:not(:first-child){
       border-left: 1px solid @interface-color-gray-2;
@@ -197,6 +202,27 @@ nav.navbar {
   .navbar-brand {
     padding: 0;
     margin-left: 0;
+  }
+
+  @media (max-width: @screen-md-max) {
+
+    ul.navbar-nav {
+
+      .navbar-collapse {
+        padding: 0;
+      }
+    }
+
+    .dropdown {
+
+      button.dropdown-toggle {
+        width: 100%;
+      }
+
+      ul.dropdown-menu {
+        padding-left: @interface-internal-spacing * 2;
+      }
+    }
   }
 }
 

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -151,18 +151,32 @@ td.author { max-width: 150px; }
 
         button.go{ width: 100%; margin-top: 5px; } } }
 
-/* navbar */
 nav.navbar {
 
-    .navbar-toggle { margin-right: 1px; border: 0; border-radius: 0; padding: 10px; }
+  .navbar-toggle {
+    border-radius: 0;
+    border: 0;
+    margin-right: 1px;
+    padding: 10px;
+  }
 
-    ul li {
+  ul li {
 
-        &:not(:first-child){ border-left: 1px solid #F1F1F1; }
+    &:not(:first-child){
+      border-left: 1px solid #F1F1F1;
+    }
 
-        i { padding-right: 4px; margin-left: -4px; } }
+    i {
+      margin-left: -4px;
+      padding-right: 4px;
+    }
+  }
 
-    .navbar-brand { padding: 0px; margin-left: 0; } }
+  .navbar-brand {
+    padding: 0px;
+    margin-left: 0;
+  }
+}
 
 .navbar-save { font-size: inherit; line-height: inherit; margin: 1px;
 

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -1,5 +1,6 @@
 @import url('bootstrap-navbar-override.less');
 @import 'mixins/_mixin-buttons';
+@import '_colors';
 @import '_sizing';
 
 .cf:before, .cf:after { content: " "; display: table; }
@@ -152,6 +153,32 @@ td.author { max-width: 150px; }
         button.go{ width: 100%; margin-top: 5px; } } }
 
 nav.navbar {
+  @icon-spacing: 5px;
+
+  .dropdown {
+
+    button.dropdown-toggle {
+      .mixin-button-no-style();
+
+      padding: @interface-internal-spacing;
+
+      &[aria-expanded="true"] {
+        background-color: @interface-color-gray-2;
+      }
+
+      span {
+        margin-right: @icon-spacing;
+      }
+    }
+
+    ul.dropdown-menu {
+
+      li.active a {
+        background-color: @interface-color-gray-2;
+        color: inherit;
+      }
+    }
+  }
 
   .navbar-toggle {
     border-radius: 0;
@@ -163,17 +190,12 @@ nav.navbar {
   ul li {
 
     &:not(:first-child){
-      border-left: 1px solid #F1F1F1;
-    }
-
-    i {
-      margin-left: -4px;
-      padding-right: 4px;
+      border-left: 1px solid @interface-color-gray-2;
     }
   }
 
   .navbar-brand {
-    padding: 0px;
+    padding: 0;
     margin-left: 0;
   }
 }

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -171,16 +171,17 @@ nav.navbar {
         color: @interface-color-gray-6;
       }
 
-      ul.dropdown-menu li {
+    }
 
-        &.active a {
-          background-color: @interface-color-gray-2;
-          color: inherit;
-        }
+    ul.dropdown-menu li {
 
-        a {
-          padding: @interface-internal-spacing/2 @interface-internal-spacing;
-        }
+      &.active a {
+        background-color: @interface-color-gray-2;
+        color: inherit;
+      }
+
+      a {
+        padding: @interface-internal-spacing/2 @interface-internal-spacing;
       }
     }
   }
@@ -205,6 +206,11 @@ nav.navbar {
   }
 
   @media (max-width: @screen-md-max) {
+
+    .navbar-header > .navbar-toggle {
+      font-size: 23px;
+      padding: 0 10px;
+    }
 
     ul.navbar-nav {
 

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -26,6 +26,42 @@
         id="navbar-collapse">
 
       <ul class="nav navbar-nav">
+
+        <li
+          class="collapse navbar-collapse"
+          id="navbar-collapse">
+
+        <div class="dropdown">
+          <button
+              class="dropdown-toggle"
+              data-toggle="dropdown">
+            <span>Create</span>
+            <i class="fa fa-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu">
+            <active-nav
+                href="/cms/app/campaigns/"
+                label="Campaigns">
+            </active-nav>
+            <active-nav
+                href="/cms/app/notifications/"
+                label="Notifications">
+            </active-nav>
+            <active-nav
+                href="/cms/app/polls/"
+                label="Polls">
+            </active-nav>
+            <active-nav
+                href="/cms/app/section/"
+                label="Sections">
+            </active-nav>
+            <active-nav
+                href="/cms/app/special-coverage/"
+                label="Special Coverage">
+            </active-nav>
+          </div>
+        </li>
+
         <active-nav
             href="/cms/app/list/"
             label="Content">
@@ -42,28 +78,8 @@
             label="Reporting">
         </active-nav>
         <active-nav
-            href="/cms/app/notifications/"
-            label="Notifications">
-        </active-nav>
-        <active-nav
             href="/cms/app/cms-notifications/"
             label="CMS Alerts">
-        </active-nav>
-        <active-nav
-            href="/cms/app/campaigns/"
-            label="Campaigns">
-        </active-nav>
-        <active-nav
-            href="/cms/app/special-coverage/"
-            label="Special Coverage">
-        </active-nav>
-        <active-nav
-            href="/cms/app/section/"
-            label="Sections">
-        </active-nav>
-        <active-nav
-            href="/cms/app/polls/"
-            label="Polls">
         </active-nav>
         <active-nav
             href="/cms/app/super-features/"

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -24,6 +24,30 @@
 
       <ul class="nav navbar-nav">
 
+        <active-nav
+            href="/cms/app/list/"
+            label="Content">
+        </active-nav>
+        <active-nav
+            href="/cms/app/promotion/"
+            label="Promotion"
+            hide-if-forbidden
+            options-url="/cms/api/v1/pzone/">
+        </active-nav>
+        <active-nav
+            ng-show="currentUser.is_manager"
+            href="/cms/app/reporting/"
+            label="Reporting">
+        </active-nav>
+        <active-nav
+            href="/cms/app/cms-notifications/"
+            label="CMS Alerts">
+        </active-nav>
+        <active-nav
+            href="/cms/app/super-features/"
+            label="Super Features">
+        </active-nav>
+
         <li
           class="collapse navbar-collapse"
           id="navbar-collapse">
@@ -59,29 +83,6 @@
           </div>
         </li>
 
-        <active-nav
-            href="/cms/app/list/"
-            label="Content">
-        </active-nav>
-        <active-nav
-            href="/cms/app/promotion/"
-            label="Promotion"
-            hide-if-forbidden
-            options-url="/cms/api/v1/pzone/">
-        </active-nav>
-        <active-nav
-            ng-show="currentUser.is_manager"
-            href="/cms/app/reporting/"
-            label="Reporting">
-        </active-nav>
-        <active-nav
-            href="/cms/app/cms-notifications/"
-            label="CMS Alerts">
-        </active-nav>
-        <active-nav
-            href="/cms/app/super-features/"
-            label="Super Features">
-        </active-nav>
       </ul>
 
       <ul class="nav navbar-nav navbar-right">

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -1,16 +1,30 @@
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav
+    class="navbar navbar-default navbar-fixed-top"
+    role="navigation">
   <div class="container-fluid">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+      <button
+          type="button"
+          class="navbar-toggle"
+          data-toggle="collapse"
+          data-target="#navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a id="logo" class="navbar-brand" href="/cms/app/list/"><img ng-src="{{ NAV_LOGO }}"></a>
+      <a
+          id="logo"
+          class="navbar-brand"
+          href="/cms/app/list/">
+        <img ng-src="{{ NAV_LOGO }}">
+      </a>
     </div>
 
-    <div class="collapse navbar-collapse" id="navbar-collapse">
+    <div
+        class="collapse navbar-collapse"
+        id="navbar-collapse">
+
       <ul class="nav navbar-nav">
         <active-nav
             href="/cms/app/list/"

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -8,10 +8,7 @@
           class="navbar-toggle"
           data-toggle="collapse"
           data-target="#navbar-collapse">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+        <i class="fa fa-bars"></i>
       </button>
       <a
           id="logo"

--- a/app/views/toolbar.html
+++ b/app/views/toolbar.html
@@ -2,11 +2,12 @@
   <div class="container-fluid">
     <div class="navbar-header">
       <a id="logo" class="navbar-brand" href="/cms/app/list"><img ng-src="{{ NAV_LOGO }}"></a>
-      <button type="button" class="navbar-toggle pull-right" data-toggle="collapse" data-target="#navbar-collapse">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
+      <button
+        type="button"
+        class="navbar-toggle pull-right"
+        data-toggle="collapse"
+        data-target="#navbar-collapse">
+        <i class="fa fa-bars"></i>
       </button>
       <button
           class="navbar-save btn btn-success navbar-btn visible-xs-inline pull-right"


### PR DESCRIPTION
Provide styles for a dropdown menu in main CMS navigation. Allows us to move some nav items into a menu to make a horizontally shorter nav.

**Release Type**: _patch_
No new major features, no breaking changes. Adding a small amount of new styles, minor modifications to others.

**New**

1. Added styling for `.dropdown` in `nav` element.

**Updates**

1. Normalized padding of items in nav: 10px all around.

2. Some readability changes, moving style attributes to their own lines.

3. Updated example `nav.html` to use a dropdown as sites would.

4. Removed `icon-bars` style since this can be replaced with a single `fa-bars` class.
