### PR TITLE
editor to 1.0.4

### DIFF
--- a/app/components/date-time-modal/date-time-modal-controller.tests.js
+++ b/app/components/date-time-modal/date-time-modal-controller.tests.js
@@ -100,7 +100,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
     it('returns the given date in the configured timezone', function () {
       buildControllerInstance();
       expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('ZZ'));
-    })
+    });
   });
 
   describe('setDateToday', function () {

--- a/app/components/date-time-modal/date-time-modal-controller.tests.js
+++ b/app/components/date-time-modal/date-time-modal-controller.tests.js
@@ -55,7 +55,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
   it('has a TIMEZONE_LABEL', function () {
     CmsConfigProviderHook.setTimezoneName('America/Chicago');
     buildControllerInstance();
-    expect($scope.TIMEZONE_LABEL).to.equal('CDT');
+    expect($scope.TIMEZONE_LABEL).to.equal(moment.tz('America/Chicago').format('z'));
   });
 
   it('has a dateTime', function () {
@@ -87,7 +87,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the current date and time in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.match(/GMT-0500/);
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().format('zZZ'));
     });
   });
 
@@ -99,7 +99,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the given date in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.match(/GMT-0500/);
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().format('zZZ'));
     });
   });
 

--- a/app/components/date-time-modal/date-time-modal-controller.tests.js
+++ b/app/components/date-time-modal/date-time-modal-controller.tests.js
@@ -87,7 +87,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the current date and time in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.have.string(moment().format('zZZ'));
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('zZZ'));
     });
   });
 
@@ -99,7 +99,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the given date in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.have.string(moment().format('zZZ'));
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('zZZ'));
     });
   });
 

--- a/app/components/date-time-modal/date-time-modal-controller.tests.js
+++ b/app/components/date-time-modal/date-time-modal-controller.tests.js
@@ -87,7 +87,7 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the current date and time in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('zZZ'));
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('ZZ'));
     });
   });
 
@@ -99,8 +99,8 @@ describe('Controller: DatetimeSelectionModalCtrl', function () {
 
     it('returns the given date in the configured timezone', function () {
       buildControllerInstance();
-      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('zZZ'));
-    });
+      expect($scope.nowInTimezone().toString()).to.have.string(moment().tz('America/Chicago').format('ZZ'));
+    })
   });
 
   describe('setDateToday', function () {

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "lodash": "~3.1.0",
     "moment-timezone": "~0.5.4",
     "moment": "~2.13.0",
-    "onion-editor": "theonion/editor#1.0.3",
+    "onion-editor": "theonion/editor#1.0.4",
     "pnotify": "~2.0.0",
     "raven-js": "1.1.11",
     "restangular": "~1.4.0",


### PR DESCRIPTION
Use [editor#1.0.4](https://github.com/theonion/editor/releases/tag/1.0.4).

**Release Type**: _patch_
Minor version update of `editor` dependency, no breaking changes.

**New**

1. Per new `editor` version, all inline links created with the CMS now get `target="_blank"`.