### PR TITLE
add description field to super feature edit page

### DIFF
--- a/app/components/super-features/super-features-edit/super-features-edit.html
+++ b/app/components/super-features/super-features-edit/super-features-edit.html
@@ -53,6 +53,13 @@
       placeholder="Subhead (optional)">
   </onion-editor>
 
+  <onion-editor
+      id="content-description"
+      ng-model="article.description"
+      role="singline"
+      placeholder="Description goes here">
+  </onion-editor>
+
   <div class="row well">
     <label
         class="muted-capitals"


### PR DESCRIPTION
Adds missing description field to super features.

### Release Type: _patch_
No major changes, only an addition.

### New

1. Super feature edit pages now have a description field.