### PR TITLE
live blog iteration 3 phase 1

### DIFF
--- a/app/components/live-blog/live-blog-entries/live-blog-entries.html
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.html
@@ -54,6 +54,14 @@
     </button>
   </div>
 
+  <div class="input-container">
+    <label for="liveBlogEntriesBeforeMore">Entries to Display Before "Show More"</label>
+    <input
+        ng-model="article.number_of_entries_before_more"
+        id="liveBlogEntriesBeforeMore"
+        type="number">
+  </div>
+
   <div
       ng-if="errorMessage"
       class="live-blog-entries-list-error">
@@ -69,14 +77,6 @@
       class="live-blog-entries-list-no-items">
     No entries yet!
   </div>
-</div>
-
-<div class="input-container">
-  <label for="liveBlogEntriesBeforeMore">Entries to Display Before "Show More"</label>
-  <input
-      ng-model="article.number_of_entries_before_more"
-      id="liveBlogEntriesBeforeMore"
-      type="number">
 </div>
 
 <ol ng-if="entries.length > 0">

--- a/app/components/live-blog/live-blog-entries/live-blog-entries.html
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.html
@@ -71,6 +71,14 @@
   </div>
 </div>
 
+<div class="input-container">
+  <label for="liveBlogEntriesBeforeMore">Entries to Display Before "Show More"</label>
+  <input
+      ng-model="article.number_of_entries_before_more"
+      id="liveBlogEntriesBeforeMore"
+      type="number">
+</div>
+
 <ol ng-if="entries.length > 0">
   <li ng-repeat="entry in entries track by entry.id">
 

--- a/app/components/live-blog/live-blog-entries/live-blog-entries.less
+++ b/app/components/live-blog/live-blog-entries/live-blog-entries.less
@@ -24,7 +24,7 @@ live-blog-entries {
     .live-blog-entries-header-meta-tools {
       .clearfix;
 
-      margin-bottom: @interface-row-margin;
+      margin-bottom: @interface-internal-spacing;
 
       button:not(:first-child) {
         margin-left: 10px;

--- a/app/mocks/api-mock-data.js
+++ b/app/mocks/api-mock-data.js
@@ -464,11 +464,12 @@ angular.module('bulbsCmsApp.mockApi.data', [])
         recirc_query: {}
       }, {
         id: 16,
-        title: 'Live Blog #1',
-        slug: 'live-blog-1',
+        number_of_entries_before_more: 15,
         pinned_content: [],
         polymorphic_ctype: 'mock_live_blog',
         recirc_query: {},
+        slug: 'live-blog-1',
+        title: 'Live Blog #1',
       }, {
         id: 100,
         title: 'Guide to Catz',

--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -20,6 +20,7 @@
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-list/dynamic-content-form-field-list.less";
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-object/dynamic-content-form-field-object.less";
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-richtext/dynamic-content-form-field-richtext.less";
+@import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-slideshow-ids/dynamic-content-form-field-slideshow-ids.less";
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-text/dynamic-content-form-field-text.less";
 @import "../components/super-features/super-features-tab/super-features-tab.less";
 @import "../components/campaigns/campaigns-edit/campaigns-edit-sponsor-pixel/campaigns-edit-sponsor-pixel.less";

--- a/app/styles/edit-page.less
+++ b/app/styles/edit-page.less
@@ -68,9 +68,9 @@ section .row .well { margin-bottom: 20px; }
 .metadata label { margin-top: 10px; }
 
 
- .editorPlaceholder {
- 	color: #ccc;
- }
+.editorPlaceholder {
+  color: #a9a9a9;
+}
 
 #content-title {
     .editor, .editorPlaceholder { padding-top: 10px; min-height: 50px; }

--- a/app/styles/mixins/_mixin-input-container.less
+++ b/app/styles/mixins/_mixin-input-container.less
@@ -10,6 +10,8 @@
 .mixin-input (@width: 100%) {
   background-color: @interface-color-white;
   border: 1px solid @interface-color-gray-4;
+  border-radius: 3px;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
   font-size: @interface-font-size-2;
   line-height: @interface-font-size-2;
   max-width: @width;


### PR DESCRIPTION
Corresponds to changes in https://github.com/theonion/omni/pull/941.

### Release Type: _minor_
No breaking changes introduced. Backends that don't have a `number_of_entries_before_more` field for live blogs will have a new field that doesn't hook up with anything, but the CMS will still function.

### New

1. New field to enter `number_of_entries_before_more` for live blogs.

### Changed

1. Reduced space between live blog meta tools and the following CMS content.
2. Color of editor input placeholder text now matches the color of placeholder text in other inputs.
3. Live blog field styling now matches styling of other CMS elements.
