### PR TITLE
replace status bar with new word count component

### DIFF
--- a/app/components/editor/editor-wrapper/editor-wrapper.js
+++ b/app/components/editor/editor-wrapper/editor-wrapper.js
@@ -102,7 +102,6 @@ angular.module('bulbs.cms.editor.wrapper', [
                 // Sean, you can figure out a nicer way to handle the search handler.
                 searchHandler: window[attrs.linkSearchHandler] || false
               },
-              statsContainer: '.wordcount',
               inlineObjects: attrs.inlineObjects || CmsConfig.getInlineObjecsPath(),
               image: {
                 insertDialog: BettyCropper.upload,

--- a/app/components/word-count/word-count.js
+++ b/app/components/word-count/word-count.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular.module('bulbs.cms.wordCount', [
+  'jquery'
+])
+  .directive('wordCount', [
+    '$', '$interval',
+    function ($, $interval) {
+
+      return {
+        link: function (scope, element) {
+
+          var calcWordCount = function () {
+            return $(scope.textContainers)
+              .toArray()
+              .reduce(function (count, element) {
+                return count + $(element).text().split(' ').length;
+              }, 0);
+          };
+
+          var initializer = $interval(function () {
+            var wordCount = calcWordCount();
+
+            if (wordCount > 0) {
+              $interval.cancel(initializer);
+            }
+
+            scope.wordCount = wordCount;
+          }, 1000);
+
+          $(document).on('keyup', scope.textContainers, function () {
+            scope.wordCount = calcWordCount();
+          });
+        },
+        restrict: 'E',
+        scope: {
+          textContainers: '@'
+        },
+        template: '{{ wordCount || 0 }}'
+      };
+    }
+  ]);

--- a/app/components/word-count/word-count.less
+++ b/app/components/word-count/word-count.less
@@ -1,0 +1,11 @@
+word-count {
+  position: fixed;
+  bottom: 0px;
+  right: 0px;
+  width: 60px;
+  font-size: 14px;
+  text-align: right;
+  color: #666;
+  padding: 15px 20px 15px 20px;
+  background-color: #ddd;
+}

--- a/app/components/word-count/word-count.tests.js
+++ b/app/components/word-count/word-count.tests.js
@@ -1,0 +1,74 @@
+'use strict';
+
+describe('Directive: wordCount', function () {
+
+  var $;
+  var $interval;
+  var $parentScope;
+  var testContainer;
+  var digest;
+  var element;
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+
+    module('bulbs.cms.wordCount');
+    module('jquery');
+
+    inject(function (_$_, _$interval_, $compile, $rootScope) {
+
+      $ = _$_;
+      $interval = _$interval_;
+      $parentScope = $rootScope.$new();
+
+      testContainer = $('<div class="test-container"></div>');
+      $(document.body).append(testContainer);
+
+      element = window.testHelper.directiveBuilderWithDynamicHtml(
+        $compile,
+        $parentScope
+      )('<word-count text-containers=".test-container .editor"></word-count>');
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    testContainer.remove();
+  });
+
+  it('should pick up on text elements to count that are added late', function () {
+
+    testContainer.append('<div class="editor">this is four words</div>');
+    $interval.flush(1000);
+    $parentScope.$digest();
+
+    expect(element.html()).to.equal('4');
+  });
+
+  it('should count words from multiple selected text elements', function () {
+    testContainer.append('<div class="editor">this is four words</div>');
+    testContainer.append('<div class="editor">this is another five words</div>');
+
+    $interval.flush(1000);
+    $parentScope.$digest();
+
+    expect(element.html()).to.equal('9');
+  });
+
+  it('should update word count each time a keyup event fires on a selected text element', function () {
+    var editor = $('<div class="editor">only three words</div>');
+    testContainer.append(editor);
+
+    editor.html('this is four words');
+    editor.trigger('keyup');
+    $parentScope.$digest();
+
+    expect(element.html()).to.equal('4');
+  });
+
+  it('should default word count to 0', function () {
+
+    expect(element.html()).to.equal('0');
+  });
+});

--- a/app/components/word-count/word-count.tests.js
+++ b/app/components/word-count/word-count.tests.js
@@ -6,7 +6,6 @@ describe('Directive: wordCount', function () {
   var $interval;
   var $parentScope;
   var testContainer;
-  var digest;
   var element;
   var sandbox;
 

--- a/app/index.html
+++ b/app/index.html
@@ -263,6 +263,7 @@
     <script src="components/top-bar/top-bar-directive.js"></script>
     <script src="components/top-bar/top-bar-item-factory.js"></script>
     <script src="components/top-bar/top-bar.js"></script>
+    <script src="components/word-count/word-count.js"></script>
     <script src="shared/api-services/api-services-mixins/mixin-field-display.js"></script>
     <script src="shared/api-services/api-services.js"></script>
     <script src="shared/api-services/campaign/campaign-factory.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -17,6 +17,7 @@ angular.module('bulbsCmsApp', [
   'bulbs.cms.site.config',
 
   'bulbs.cms.superFeatures',
+  'bulbs.cms.wordCount',
 
   // TODO : these dependencies need to be reorganized, localized
   'bulbs.cms.currentUser',

--- a/app/styles/_components.less
+++ b/app/styles/_components.less
@@ -2,7 +2,7 @@
 
 // injector:less_components
 @import "../components/filter-list-widget/filter-list-widget.less";
-@import "../components/title-modal/title-modal.less";
+@import "../components/word-count/word-count.less";
 @import "../components/filter-widget/filter-widget.less";
 @import "../components/campaign-autocomplete/campaign-autocomplete.less";
 @import "../components/campaigns/campaigns-edit/campaigns-edit.less";
@@ -22,7 +22,7 @@
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-richtext/dynamic-content-form-field-richtext.less";
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-slideshow-ids/dynamic-content-form-field-slideshow-ids.less";
 @import "../components/dynamic-content/dynamic-content-form/dynamic-content-form-field/dynamic-content-form-field-text/dynamic-content-form-field-text.less";
-@import "../components/super-features/super-features-tab/super-features-tab.less";
+@import "../components/title-modal/title-modal.less";
 @import "../components/campaigns/campaigns-edit/campaigns-edit-sponsor-pixel/campaigns-edit-sponsor-pixel.less";
 @import "../components/live-blog/live-blog-entries/live-blog-entries.less";
 @import "../components/live-blog/live-blog-responses/live-blog-responses.less";
@@ -41,6 +41,7 @@
 @import "../components/super-features/super-features-relations/super-features-relations-modal/super-features-relations-modal.less";
 @import "../components/super-features/super-features-relations/super-features-relations.less";
 @import "../components/super-features/super-features-tab/super-features-tab-item/super-features-tab-item.less";
+@import "../components/super-features/super-features-tab/super-features-tab.less";
 @import "../components/breadcrumb/breadcrumb.less";
 @import "../components/autocomplete-basic/autocomplete-basic.less";
 // endinjector:less_components

--- a/app/styles/edit-page.less
+++ b/app/styles/edit-page.less
@@ -51,8 +51,6 @@
 
 .errors-panel ul { list-style-type: none }
 
-.status-bar { position: fixed; bottom: 0px; right: 0px; width: 60px; font-size: 14px; text-align: right; color: #666; padding: 15px 20px 15px 20px; background-color: #ddd; }
-
 section .h6, section .h5 { margin: 0px; font-weight: 700; }
 
 section .row .well { margin-bottom: 20px; }

--- a/app/views/contentedit.html
+++ b/app/views/contentedit.html
@@ -33,9 +33,7 @@
         Error: article has no content type.
       </h4>
     </div>
-    <div class="status-bar">
-      <span class="wordcount"></span>
-    </div>
+    <word-count text-containers=".editor"></word-count>
   </div>
 </div>
 


### PR DESCRIPTION
Current status bar doesn't work properly, replace it with a component that counts words correctly.

### Release Type: _minor_
No major changes, status line being removed was pretty much broken anyways.

### New

1. Added `word-count` component that sums the counts of all words in all `.editor` (or whatever selector is passed into it) elements on the page.

### Removed

1. Broken `status-bar` element and related markup and styles.