### PR TITLE
[SSL] Update default Youtube thumbnail URL to HTTPS

### DIFF
--- a/app/views/inline-objects.json
+++ b/app/views/inline-objects.json
@@ -45,7 +45,7 @@
       "caption": ""
     },
     "template":
-    "<div data-type=\"youtube\" class=\"youtube inline size-{{size}} crop-{{crop}}\" data-youtube-id=\"{{youtube_id}}\" data-size=\"{{size}}\" data-crop=\"{{crop}}\"><div><img src=\"http://img.youtube.com/vi/{{youtube_id}}/hqdefault.jpg\"></div<span class=\"caption\">{{caption}}</span></div>"
+    "<div data-type=\"youtube\" class=\"youtube inline size-{{size}} crop-{{crop}}\" data-youtube-id=\"{{youtube_id}}\" data-size=\"{{size}}\" data-crop=\"{{crop}}\"><div><img src=\"https://img.youtube.com/vi/{{youtube_id}}/hqdefault.jpg\"></div<span class=\"caption\">{{caption}}</span></div>"
   },
   "pullquote": {
     "size": ["big", "small"],


### PR DESCRIPTION
Youtube supports HTTPS thumbnails: https://img.youtube.com/vi/wMUAH4LBh3g/hqdefault.jpg

Turns out each property overrides this anyway, but I already did did the work so might as well commit. 