### PR TITLE
removing the button, minimally

### DIFF
--- a/app/scripts/controllers/reporting.js
+++ b/app/scripts/controllers/reporting.js
@@ -3,8 +3,7 @@
 angular.module('bulbsCmsApp')
   .controller('ReportingCtrl', function ($http, $scope, $modal, $window, $,
       $location, $filter, $interpolate, Login, moment, CmsConfig,
-      ContributionReportingService, ContentReportingService,
-      FreelancePayReportingService) {
+      ContributionReportingService, ContentReportingService) {
 
     $window.document.title = CmsConfig.getCmsName() + ' | Reporting';
 
@@ -72,17 +71,6 @@ angular.module('bulbsCmsApp')
         ],
         orderOptions: [],
         downloadURL: '/cms/api/v1/contributions/contentreporting/',
-      },
-      'Freelance Pay': {
-        service: FreelancePayReportingService,
-        headings: [
-          {'title': 'Contributor', 'expression': 'contributor.full_name'},
-          {'title': 'Contribution #', 'expression': 'contributions_count'},
-          {'title': 'Pay', 'expression': 'pay'},
-          {'title': 'Payment Date', 'expression': 'payment_date | date: \'MM/dd/yyyy\''}
-        ],
-        orderOptions: [],
-        downloadURL: '/cms/api/v1/contributions/freelancereporting/'
       }
     };
     $scope.items = [];


### PR DESCRIPTION
**Purpose**
Remove the freelance pay report option from the reporting page in the CMS.

**Notes**
Not sure if I need to remove anything from other files, but this definitely got rid of the option on the front end.

**Test Link**
http://rm-freelance-pay.test.avclub.com/cms/app/reporting/

@spra85 not sure who else should review