### PR TITLE
testing out a fix for floating images in the editor

### DIFF
--- a/app/components/editor/editor-wrapper/editor-wrapper.html
+++ b/app/components/editor/editor-wrapper/editor-wrapper.html
@@ -1,6 +1,6 @@
 <div class="editor-wrapper">
     <div class="editorPlaceholder"></div>
-    <div class="editor" contenteditable="true"></div>
+    <div class="editor clearfix" contenteditable="true"></div>
 
     <div class="document-tools toolbar fixed">
       <div class="toolbar-contents">


### PR DESCRIPTION
@theonion/front-end I found this issue when testing for this ticket: https://app.asana.com/0/342156387987716/355037726440162

**Purpose**
Add a clearfix to the editor field so floating images don't fall outside of the editor box (particularly problematic on the live blog entries)

<img width="788" alt="screen shot 2017-06-05 at 4 23 44 pm" src="https://cloud.githubusercontent.com/assets/7442289/26805200/dd8e0890-4a18-11e7-8847-35761c677077.png">

**Test Link**
http://editor-clearfix.test.avclub.com/cms
To test, create a new live blog entry, add an image, change the size to small or tiny (they both float right on av) and the box will expand to contain the image.